### PR TITLE
[bookkeeper] Issue 14: Updating bookkeeper image version to 0.9.1

### DIFF
--- a/charts/bookkeeper/Chart.yaml
+++ b/charts/bookkeeper/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bookkeeper
 description: Bookkeeper Helm chart for Kubernetes
 version: 0.9.1
-appVersion: 0.9.0
+appVersion: 0.9.1
 keywords:
   - log storage
   - stream storage

--- a/charts/bookkeeper/README.md
+++ b/charts/bookkeeper/README.md
@@ -142,7 +142,7 @@ The following table lists the configurable parameters of the Bookkeeper chart an
 
 | Parameter | Description | Default |
 | ----- | ----------- | ------ |
-| `version` | Bookkeeper version | `0.9.0` |
+| `version` | Bookkeeper version | `0.9.1` |
 | `image.repository` | Image repository | `pravega/bookkeeper` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `replicas` | Number of bookkeeper replicas | `3` |

--- a/charts/bookkeeper/values.yaml
+++ b/charts/bookkeeper/values.yaml
@@ -2,7 +2,7 @@
 ## This is a YAML-formatted file.
 ## Declare variables to be passed into your templates.
 
-version: 0.9.0
+version: 0.9.1
 
 image:
   repository: pravega/bookkeeper


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
Updating bookkeeper charts to use bookkeeper image 0.9.1

### Purpose of the change
Fixes #14 

### What the code does
Updates the AppVersion and the image version to 0.9.1 inside the bookkeeper charts.

### How to verify it
Running the following commands should install the bookkeeper cluster with image 0.9.1
```
helm repo add pravega https://charts.pravega.io
helm repo update
helm install bookkeeper pravega/bookkeeper
```

### Checklist
- [X] PR title starts with the name of the chart followed by the issue number (e.g. `[bookkeeper-operator] Issue XX: "Description"`)
- [X] Verified output of helm lint
- [X] Changes have been tested manually
