### PR TITLE
[bookkeeper-operator] Issue 16: Bumping bookeeper operator chart version

### DIFF
--- a/charts/bookkeeper-operator/Chart.yaml
+++ b/charts/bookkeeper-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: bookkeeper-operator
 description: Bookkeeper Operator Helm chart for Kubernetes
-version: 0.2.0
+version: 0.2.1
 appVersion: 0.1.5
 keywords:
   - log storage


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
Bumps up the bookkeeper operator chart version to 0.2.1

### Purpose of the change
Fixes #16 

### What the code does
Bumps up the bookkeeper operator chart version to 0.2.1

### How to verify it
Not applicable

### Checklist
- [X] PR title starts with the name of the chart followed by the issue number (e.g. `[bookkeeper-operator] Issue XX: "Description"`)
- [X] Verified output of helm lint
- [ ] Changes have been tested manually
