### PR TITLE
[pravega-operator] Issue 20: Deprecating supported versions map

### DIFF
--- a/charts/pravega-operator/Chart.yaml
+++ b/charts/pravega-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: pravega-operator
 description: Pravega Operator Helm chart for Kubernetes
-version: 0.5.3
-appVersion: 0.5.3
+version: 0.6.0
+appVersion: 0.5.4
 keywords:
 - pravega
 - storage

--- a/charts/pravega-operator/README.md
+++ b/charts/pravega-operator/README.md
@@ -53,15 +53,15 @@ The following table lists the configurable parameters of the pravega-operator ch
 | Parameter | Description | Default |
 | ----- | ----------- | ------ |
 | `image.repository` | Image repository | `pravega/pravega-operator` |
-| `image.tag` | Image tag | `0.5.3` |
+| `image.tag` | Image tag | `0.5.4` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `crd.create` | Create pravega CRD | `true` |
 | `rbac.create` | Create RBAC resources | `true` |
 | `serviceAccount.create` | Create service account | `true` |
 | `serviceAccount.name` | Name for the service account | `pravega-operator` |
 | `testmode.enabled` | Enable test mode | `false` |
-| `testmode.version` | Major version number of the alternate pravega image we want the operator to deploy or provide an upgrade path to, if test mode is enabled | `""` |
-| `testmode.fromVersion` | Major version number of the alternate pravega image, if we wish to provide an upgrade path from this version to the version mentioned above, if test mode is enabled | `""` |
+| `testmode.version` | `DEPRECATED` Major version number of the alternate pravega image we want the operator to deploy or provide an upgrade path to, if test mode is enabled | `""` |
+| `testmode.fromVersion` | `DEPRECATED` Major version number of the alternate pravega image, if we wish to provide an upgrade path from this version to the version mentioned above, if test mode is enabled | `""` |
 | `webhookCert.crt` | tls.crt value corresponding to the certificate | |
 | `webhookCert.key` | tls.key value corresponding to the certificate | |
 | `webhookCert.generate` | Whether to generate the certificate and the issuer (set to false while using self-signed certificates) | `false` |

--- a/charts/pravega-operator/values.yaml
+++ b/charts/pravega-operator/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: pravega/pravega-operator
-  tag: 0.5.3
+  tag: 0.5.4
   pullPolicy: IfNotPresent
 
 ## Install RBAC roles and bindings.
@@ -26,15 +26,17 @@ testmode:
   ## version is used to specify the major version number
   ## of the unreleased pravega version that you wish to deploy
   ## or provide an upgrade path to
-  ## Note: mention the major version number
+  ## Mention the major version number
   ## enter 0.8.3 if u wish to deploy version 0.8.3-2500.efe501a
+  ## NOTE: this field is deprecated and will be removed in future releases
   version: ""
   ## fromVersion is used to specify the major version number
   ## of the unreleased pravega version you wish to provide an upgrade path from
   ## i.e. if you wish to provide an upgrade path from this unreleased version (testmode.fromVersion)
   ## to the unreleased version number specified by the previous field (testmode.version)
-  ## Note: mention the major version number
+  ## Mention the major version number
   ## eg. enter 0.7.4 if u wish to provide an upgrade path from pravega 0.7.4 to 0.8.3
+  ## NOTE: this field is deprecated and will be removed in future releases
   fromVersion: ""
 
 webhookCert:


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
Deprecates the supported versions configmap from the pravega operator charts. The version map will be completely removed in a later operator release.

### Purpose of the change
Fixes #20 

### What the code does
This change along with [this](https://github.com/pravega/pravega-operator/pull/565) PR on the pravega operator repository helps us get rid of the version map dependency.

### How to verify it
The pravega operator installed using the latest charts should allow installation of any pravega version given in the correct format (i.e. *MAJOR*.*MINOR*.*PATCH*-*XXXX*), and should also allow upgrades to any other pravega version. Downgrades are however not allowed.

### Checklist
- [X] PR title starts with the name of the chart followed by the issue number (e.g. `[bookkeeper-operator] Issue XX: "Description"`)
- [X] Verified output of helm lint
- [X] Changes have been tested manually
