### PR TITLE
[pravega] Issue 18: make version format consistent

### DIFF
--- a/charts/pravega/templates/pravega.yaml
+++ b/charts/pravega/templates/pravega.yaml
@@ -31,7 +31,7 @@ spec:
     controllerTokenSecret: {{ .Values.authentication.controllerTokenSecret }}
     {{- end }}
     {{- end }}
-  version: {{ .Values.version }}
+  version: {{ .Values.image.tag }}
   zookeeperUri: {{ .Values.zookeeperUri }}
   bookkeeperUri: {{ .Values.bookkeeperUri }}
   externalAccess:

--- a/charts/pravega/values.yaml
+++ b/charts/pravega/values.yaml
@@ -2,8 +2,6 @@
 ## This is a YAML-formatted file.
 ## Declare variables to be passed into your templates.
 
-version: 0.9.0
-
 tls: {}
   # secret:
   #   controller: "controller-pki"
@@ -31,6 +29,7 @@ externalAccess:
 image:
   repository: pravega/pravega
   pullPolicy: IfNotPresent
+  tag: 0.9.0
 
 hooks:
   image:


### PR DESCRIPTION
### Change log description

How the pravega ~~& bk (cluster)~~ charts specify their image is different than how the bk-operator, pravega-operator, zk-operator, and zk-cluster specify their image. Specifically, the former do:

```
version: x.y.z
```

and the rest do:

```
image:
    tag: x.y.z
```

### Purpose of the change

To unify the format that the values are given to reduce bugs caused by improper usage due to the inconsistency.

### What the code does

Changes the format.

### Checklist

- [x] PR title starts with the name of the chart followed by the issue number (e.g. `[bookkeeper-operator] Issue XX: "Description"`)
- [x] Verified output of helm lint
- [x] Changes have been tested manually