### PR TITLE
[bookkeeper] Issue 18: make version format consistent

### DIFF
--- a/charts/bookkeeper/templates/bookkeeper.yaml
+++ b/charts/bookkeeper/templates/bookkeeper.yaml
@@ -14,7 +14,7 @@ spec:
     imageSpec:
       repository: {{ .Values.image.repository }}
       pullPolicy: {{ .Values.image.pullPolicy }}
-  version: {{ .Values.version }}
+  version: {{ .Values.image.tag }}
   zookeeperUri: {{ .Values.zookeeperUri }}
   envVars: {{ template "bookkeeper.fullname" . }}-configmap
   autoRecovery: {{ .Values.autoRecovery }}

--- a/charts/bookkeeper/values.yaml
+++ b/charts/bookkeeper/values.yaml
@@ -2,11 +2,10 @@
 ## This is a YAML-formatted file.
 ## Declare variables to be passed into your templates.
 
-version: 0.9.1
-
 image:
   repository: pravega/bookkeeper
   pullPolicy: IfNotPresent
+  tag: 0.9.1
 
 hooks:
   image:


### PR DESCRIPTION
### Change log description

How the ~~pravega &~~ bk (cluster) charts specify their image is different than how the bk-operator, pravega-operator, zk-operator, and zk-cluster specify their image. Specifically, the former do:

```
version: x.y.z
```

and the rest do:

```
image:
    tag: x.y.z
```

### Purpose of the change

To unify the format that the values are given to reduce bugs caused by improper usage due to the inconsistency.

### What the code does

Changes the format.

### Checklist

- [x] PR title starts with the name of the chart followed by the issue number (e.g. `[bookkeeper-operator] Issue XX: "Description"`)
- [x] Verified output of helm lint
- [x] Changes have been tested manually
