### PR TITLE
[pravega-operator] Issue 24: Bumping pravega operator chart version

### DIFF
--- a/charts/pravega-operator/Chart.yaml
+++ b/charts/pravega-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: pravega-operator
 description: Pravega Operator Helm chart for Kubernetes
-version: 0.6.0
+version: 0.6.1
 appVersion: 0.5.4
 keywords:
 - pravega


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
Bumps up the pravega operator chart version to 0.6.1

### Purpose of the change
Fixes #24 

### What the code does
Bumps up the pravega operator chart version to 0.6.1

### How to verify it
Not applicable

### Checklist
- [X] PR title starts with the name of the chart followed by the issue number 
- [X] Verified output of helm lint
- [X] Changes have been tested manually
