### PR TITLE
[pravega] Issue 28: Add support to configure influxdb secret in pravega charts

### DIFF
--- a/charts/pravega/README.md
+++ b/charts/pravega/README.md
@@ -115,6 +115,7 @@ The following table lists the configurable parameters of the pravega chart and t
 | `authentication.passwordAuthSecret` | Name of Secret containing Password based Authentication Parameters, if authentication is enabled | |
 | `authentication.segmentStoreTokenSecret` | Name of Secret containing tokenSigningkey for the ss, if authentication is enabled | |
 | `authentication.controllerTokenSecret` | Name of Secret containing tokenSigningkey for controller, if authentication is enabled | |
+| `influxDBSecret` | Secret configuration for the influxdb | `{}` |
 | `zookeeperUri` | Zookeeper client service URI | `zookeeper-client:2181` |
 | `bookkeeperUri` | Bookkeeper headless service URI | `bookkeeper-bookie-headless:3181` |
 | `externalAccess.enabled` | Enable external access | `false` |

--- a/charts/pravega/templates/pravega.yaml
+++ b/charts/pravega/templates/pravega.yaml
@@ -149,6 +149,13 @@ spec:
       mountPath: {{ .Values.segmentStore.secret.path }}
       {{- end }}
     {{- end }}
+    {{- if .Values.influxDBSecret }}
+    influxDBSecret:
+      secret: {{ .Values.influxDBSecret.name }}
+      {{- if .Values.influxDBSecret.path }}
+      mountPath: {{ .Values.influxDBSecret.path }}
+      {{- end }}
+    {{- end }}
     {{- if .Values.controller.jvmOptions }}
     controllerjvmOptions:
 {{ toYaml .Values.controller.jvmOptions | indent 6 }}

--- a/charts/pravega/values.yaml
+++ b/charts/pravega/values.yaml
@@ -16,7 +16,10 @@ authentication:
   #segmentStoreTokenSecret:
   ##controllerTokenSecret is ignored if authentication is disabled
   #controllerTokenSecret:
-
+  
+influxDBSecret: {}
+  # name:
+  # path:
 zookeeperUri: zookeeper-client:2181
 bookkeeperUri: bookkeeper-bookie-headless:3181
 


### PR DESCRIPTION

Signed-off-by: anishakj <anisha.kj@dell.com>

### Change log description

Adding support to configure influx db secret in pravega CR
### Purpose of the change

Fixes #28

### What the code does

Added new fields in values files
### How to verify it

Verified installation of Pravega charts

### Checklist

_(Place an '[x]' (no spaces) in all applicable fields)_

- [x] PR title starts with the name of the chart followed by the issue number (e.g. `[bookkeeper-operator] Issue XX: "Description"`)
- [x] Verified output of helm lint
- [x] Changes have been tested manually
