### PR TITLE
[pravega] Issue 30: Updating pravega chart version to 0.10.0 and image version to 0.9.1

### DIFF
--- a/charts/pravega/Chart.yaml
+++ b/charts/pravega/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: pravega
 description: Pravega Helm chart for Kubernetes
-version: 0.9.1
-appVersion: 0.9.0
+version: 0.10.0
+appVersion: 0.9.1
 keywords:
 - pravega
 - storage

--- a/charts/pravega/README.md
+++ b/charts/pravega/README.md
@@ -109,7 +109,7 @@ The following table lists the configurable parameters of the pravega chart and t
 
 | Parameter | Description | Default |
 | ----- | ----------- | ------ |
-| `version` | Pravega version | `0.9.0` |
+| `version` | Pravega version | `0.9.1` |
 | `tls` | Pravega security configuration passed to the Pravega processes | `{}` |
 | `authentication.enabled` | Enable authentication to authorize client communication with Pravega | `false` |
 | `authentication.passwordAuthSecret` | Name of Secret containing Password based Authentication Parameters, if authentication is enabled | |

--- a/charts/pravega/README.md
+++ b/charts/pravega/README.md
@@ -109,7 +109,9 @@ The following table lists the configurable parameters of the pravega chart and t
 
 | Parameter | Description | Default |
 | ----- | ----------- | ------ |
-| `version` | Pravega version | `0.9.1` |
+| `image.tag` | `Version of Pravega image` | `0.9.1` |
+| `image.repository` | Image repository | `pravega/pravega` |
+| `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `tls` | Pravega security configuration passed to the Pravega processes | `{}` |
 | `authentication.enabled` | Enable authentication to authorize client communication with Pravega | `false` |
 | `authentication.passwordAuthSecret` | Name of Secret containing Password based Authentication Parameters, if authentication is enabled | |
@@ -120,8 +122,6 @@ The following table lists the configurable parameters of the pravega chart and t
 | `externalAccess.enabled` | Enable external access | `false` |
 | `externalAccess.type` | External access service type, if external access is enabled (LoadBalancer/NodePort) | `LoadBalancer` |
 | `externalAccess.domainName` | External access domain name, if external access is enabled  | |
-| `image.repository` | Image repository | `pravega/pravega` |
-| `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `debugLogging` | Enable debug logging | `false` |
 | `serviceAccount.name` | Service account to be used | `pravega-components` |
 | `controller.replicas` | Number of controller replicas | `1` |

--- a/charts/pravega/values.yaml
+++ b/charts/pravega/values.yaml
@@ -29,7 +29,7 @@ externalAccess:
 image:
   repository: pravega/pravega
   pullPolicy: IfNotPresent
-  tag: 0.9.0
+  tag: 0.9.1
 
 hooks:
   image:


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
Updating pravega charts to use pravega image 0.9.1

### Purpose of the change
Fixes #30 

### What the code does
Updates the AppVersion and the image version to 0.9.1 inside the pravega charts and the chart version to 0.10.0

### How to verify it
Running the following commands should install the pravega cluster with image 0.9.1
```
helm repo add pravega https://charts.pravega.io
helm repo update
helm install pravega pravega/pravega 
```

### Checklist
- [x] PR title starts with the name of the chart followed by the issue number
- [x] Verified output of helm lint
- [x] Changes have been tested manually
