### PR TITLE
[bookkeeper] Issue 6: Separating chart version from app version

### DIFF
--- a/charts/bookkeeper/Chart.yaml
+++ b/charts/bookkeeper/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: bookkeeper
 description: Bookkeeper Helm chart for Kubernetes
-version: 0.9.1
+version: 0.10.0
 appVersion: 0.9.1
 keywords:
   - log storage

--- a/charts/bookkeeper/README.md
+++ b/charts/bookkeeper/README.md
@@ -142,7 +142,7 @@ The following table lists the configurable parameters of the Bookkeeper chart an
 
 | Parameter | Description | Default |
 | ----- | ----------- | ------ |
-| `version` | Bookkeeper version | `0.9.1` |
+| `image.tag` | Image tag | `0.9.1` |
 | `image.repository` | Image repository | `pravega/bookkeeper` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `replicas` | Number of bookkeeper replicas | `3` |


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
Decouples the chart version of the bookkeeper charts from the underlying app version.

### Purpose of the change
Fixes #6 

### What the code does
Decouples the chart version of the bookkeeper charts from the underlying app version.

### How to verify it
The bookkeeper 0.10.0 charts should install the bookkeeper cluster version 0.9.1

### Checklist
- [x] PR title starts with the name of the chart followed by the issue number (e.g. `[bookkeeper-operator] Issue XX: "Description"`)
- [x] Verified output of helm lint
- [x] Changes have been tested manually
