### PR TITLE
[pravega] Issue 33: Bumping pravega chart version

### DIFF
--- a/charts/pravega/Chart.yaml
+++ b/charts/pravega/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: pravega
 description: Pravega Helm chart for Kubernetes
-version: 0.10.0
+version: 0.10.1
 appVersion: 0.9.1
 keywords:
 - pravega


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
Bumps up the pravega chart version to 0.10.1

### Purpose of the change
Fixes #33 

### What the code does
Bumps up the pravega chart version to 0.10.1

### How to verify it
Not applicable

### Checklist
- [x] PR title starts with the name of the chart followed by the issue number
- [x] Verified output of helm lint
- [x] Changes have been tested manually
