### PR TITLE
[pravega-operator] Issue 40: Updating pravega operator charts AppVersion to 0.5.5

### DIFF
--- a/charts/pravega-operator/Chart.yaml
+++ b/charts/pravega-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pravega-operator
 description: Pravega Operator Helm chart for Kubernetes
 version: 0.6.1
-appVersion: 0.5.4
+appVersion: 0.5.5
 keywords:
 - pravega
 - storage

--- a/charts/pravega-operator/README.md
+++ b/charts/pravega-operator/README.md
@@ -53,7 +53,7 @@ The following table lists the configurable parameters of the pravega-operator ch
 | Parameter | Description | Default |
 | ----- | ----------- | ------ |
 | `image.repository` | Image repository | `pravega/pravega-operator` |
-| `image.tag` | Image tag | `0.5.4` |
+| `image.tag` | Image tag | `0.5.5` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `crd.create` | Create pravega CRD | `true` |
 | `rbac.create` | Create RBAC resources | `true` |

--- a/charts/pravega-operator/values.yaml
+++ b/charts/pravega-operator/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: pravega/pravega-operator
-  tag: 0.5.4
+  tag: 0.5.5
   pullPolicy: IfNotPresent
 
 ## Install RBAC roles and bindings.


### PR DESCRIPTION

Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
Updating pravega operator charts AppVersion to 0.5.5

### Purpose of the change
Fixes #40 

### What the code does
Updating pravega operator charts AppVersion to 0.5.5

### How to verify it
Should install pravega-operator 0.5.5

### Checklist
- [x] PR title starts with the name of the chart followed by the issue number
- [x] Verified output of helm lint
- [x] Changes have been tested manually
