### PR TITLE
[pravega-operator] Issue 42: Bumping pravega operator chart version

### DIFF
--- a/charts/pravega-operator/Chart.yaml
+++ b/charts/pravega-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: pravega-operator
 description: Pravega Operator Helm chart for Kubernetes
-version: 0.6.1
+version: 0.6.2
 appVersion: 0.5.5
 keywords:
 - pravega


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@dell.com>

### Change log description
Bumps up the pravega operator chart version to 0.6.2

### Purpose of the change
Fixes #42 

### What the code does
Bumps up the pravega operator chart version to 0.6.2

### How to verify it
N.A.

### Checklist
- [x] PR title starts with the name of the chart followed by the issue number (e.g. `[bookkeeper-operator] Issue XX: "Description"`)
- [x] Verified output of helm lint
- [x] Changes have been tested manually
