### PR TITLE
[bookkeeper] Issue 46: Update bookkeeper template to take the default values for Volume Claim templates

### DIFF
--- a/charts/bookkeeper/templates/bookkeeper.yaml
+++ b/charts/bookkeeper/templates/bookkeeper.yaml
@@ -65,7 +65,7 @@ spec:
   resources:
 {{ toYaml .Values.resources | indent 6 }}
   {{- end }}
-{{- if .Values.storage }}
+  {{- if .Values.storage }}
   storage:
     ledgerVolumeClaimTemplate:
       accessModes: [ "ReadWriteOnce" ]
@@ -97,7 +97,7 @@ spec:
         requests:
           storage: {{ .Values.storage.index.volumeSize }}
       {{- end }}
-{{- end }}
+  {{- end }}
   {{- if and .Values.jvmOptions (or .Values.jvmOptions.memoryOpts .Values.jvmOptions.gcOpts .Values.jvmOptions.gcLoggingOpts .Values.jvmOptions.extraOpts) }}
   jvmOptions:
     {{- if .Values.jvmOptions.memoryOpts }}

--- a/charts/bookkeeper/templates/bookkeeper.yaml
+++ b/charts/bookkeeper/templates/bookkeeper.yaml
@@ -65,31 +65,39 @@ spec:
   resources:
 {{ toYaml .Values.resources | indent 6 }}
   {{- end }}
+{{- if .Values.storage }}
   storage:
     ledgerVolumeClaimTemplate:
       accessModes: [ "ReadWriteOnce" ]
       {{- if .Values.storage.ledger.className }}
       storageClassName: {{ .Values.storage.ledger.className }}
       {{- end }}
+      {{- if .Values.storage.ledger.volumeSize }}
       resources:
         requests:
           storage: {{ .Values.storage.ledger.volumeSize }}
+      {{- end }}
     journalVolumeClaimTemplate:
       accessModes: [ "ReadWriteOnce" ]
       {{- if .Values.storage.journal.className }}
       storageClassName: {{ .Values.storage.journal.className }}
       {{- end }}
+      {{- if .Values.storage.journal.volumeSize }}
       resources:
         requests:
           storage: {{ .Values.storage.journal.volumeSize }}
+      {{- end }}
     indexVolumeClaimTemplate:
       accessModes: [ "ReadWriteOnce" ]
       {{- if .Values.storage.index.className }}
       storageClassName: {{ .Values.storage.index.className }}
       {{- end }}
+      {{- if .Values.storage.index.volumeSize }}
       resources:
         requests:
           storage: {{ .Values.storage.index.volumeSize }}
+      {{- end }}
+{{- end }}
   {{- if and .Values.jvmOptions (or .Values.jvmOptions.memoryOpts .Values.jvmOptions.gcOpts .Values.jvmOptions.gcLoggingOpts .Values.jvmOptions.extraOpts) }}
   jvmOptions:
     {{- if .Values.jvmOptions.memoryOpts }}


### PR DESCRIPTION
Signed-off-by: Nishant Gupta <Nishant_Gupta3@dell.com>

### Change log description

Adding checks to take the default values for the volume claim template

### Purpose of the change

Fixes #46

### What the code does

updates the bookkeeper template to take the default values for volume claim templates 

### How to verify it

When deploying bookkeeper using charts , only provide values to certain fields of the `bookkeeper/values.yaml` storage object. In all the scenarios, if any of the value is not set by the user then it should be set to default.

Here are few scenarios to try out:
- Removing/ Commenting out the entire storage object
- Setting only className in ledger , journal and index 
- Setting only volumeSize in ledger , journal and index
- Setting only volumeSize in certain object (say ledger) and className in other (say index) and leaving both the fields of index unset


### Checklist

- [x] PR title starts with the name of the chart followed by the issue number (e.g. `[bookkeeper-operator] Issue XX: "Description"`)
- [x] Verified output of helm lint
- [x] Changes have been tested manually
