### PR TITLE
[pravega] Issue 48: Modify the default values mentioned in the sizing manifests

### DIFF
--- a/charts/pravega/values.yaml
+++ b/charts/pravega/values.yaml
@@ -93,7 +93,7 @@ segmentStore:
     annotations: {}
     loadBalancerIP:
     externalTrafficPolicy:
-  jvmOptions: ["-Xms1g", "-Xmx2g", "-XX:MaxDirectMemorySize=2g", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/tmp/dumpfile/heap", "-XX:MaxRAMPercentage=50.0", "-XX:+UseContainerSupport", "-XX:+PrintExtendedThreadInfo"]
+  jvmOptions: ["-Xms1g", "-Xmx1g", "-XX:MaxDirectMemorySize=2560m", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/tmp/dumpfile/heap", "-XX:MaxRAMPercentage=50.0", "-XX:+UseContainerSupport", "-XX:+PrintExtendedThreadInfo"]
   labels: {}
   annotations: {}
   stsNameSuffix:
@@ -143,7 +143,7 @@ options:
   bookkeeper.ack.quorum.size: "3"
   bookkeeper.write.timeout.milliseconds: "60000"
   bookkeeper.write.outstanding.bytes.max: "33554432"
-  pravegaservice.cache.size.max: "1073741824"
+  pravegaservice.cache.size.max: "1610612736"
   pravegaservice.cache.time.seconds.max: "600"
   pravegaservice.service.listener.port: "12345"
   hdfs.block.size: "67108864"

--- a/charts/pravega/values/large.yaml
+++ b/charts/pravega/values/large.yaml
@@ -32,7 +32,7 @@ segmentStore:
     ## used to override the service type for segmentStore
     type:
     annotations: {}
-  jvmOptions: ["-Xms2g", "-Xmx4g", "-XX:MaxDirectMemorySize=11g", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/tmp/dumpfile/heap", "-XX:MaxRAMPercentage=50.0", "-XX:+UseContainerSupport", "-XX:+PrintExtendedThreadInfo"]
+  jvmOptions: ["-Xms4g", "-Xmx4g", "-XX:MaxDirectMemorySize=11g", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/tmp/dumpfile/heap", "-XX:MaxRAMPercentage=50.0", "-XX:+UseContainerSupport", "-XX:+PrintExtendedThreadInfo"]
 
 options:
   bookkeeper.ensemble.size: "3"

--- a/charts/pravega/values/large.yaml
+++ b/charts/pravega/values/large.yaml
@@ -32,7 +32,7 @@ segmentStore:
     ## used to override the service type for segmentStore
     type:
     annotations: {}
-  jvmOptions: ["-Xmx4g", "-XX:MaxDirectMemorySize=12g", "-XX:MaxDirectMemorySize=2g", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/tmp/dumpfile/heap", "-XX:MaxRAMPercentage=50.0", "-XX:+UseContainerSupport", "-XX:+PrintExtendedThreadInfo"]
+  jvmOptions: ["-Xms2g", "-Xmx4g", "-XX:MaxDirectMemorySize=11g", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/tmp/dumpfile/heap", "-XX:MaxRAMPercentage=50.0", "-XX:+UseContainerSupport", "-XX:+PrintExtendedThreadInfo"]
 
 options:
   bookkeeper.ensemble.size: "3"
@@ -40,7 +40,7 @@ options:
   bookkeeper.ack.quorum.size: "3"
   bookkeeper.write.timeout.milliseconds: "60000"
   bookkeeper.write.outstanding.bytes.max: "33554432"
-  pravegaservice.cache.size.max: "11811160064"
+  pravegaservice.cache.size.max: "9663676416"
   pravegaservice.cache.time.seconds.max: "600"
   hdfs.block.size: "67108864"
   writer.flush.threshold.bytes: "67108864"

--- a/charts/pravega/values/medium.yaml
+++ b/charts/pravega/values/medium.yaml
@@ -40,7 +40,7 @@ options:
   bookkeeper.ack.quorum.size: "3"
   bookkeeper.write.timeout.milliseconds: "60000"
   bookkeeper.write.outstanding.bytes.max: "33554432"
-  pravegaservice.cache.size.max: "2147483648"
+  pravegaservice.cache.size.max: "3221225472"
   pravegaservice.cache.time.seconds.max: "600"
   hdfs.block.size: "67108864"
   writer.flush.threshold.bytes: "67108864"

--- a/charts/pravega/values/medium.yaml
+++ b/charts/pravega/values/medium.yaml
@@ -32,7 +32,7 @@ segmentStore:
     ## used to override the service type for segmentStore
     type:
     annotations: {}
-  jvmOptions: ["-Xmx4g", "-XX:MaxDirectMemorySize=4g", "-XX:MaxDirectMemorySize=2g", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/tmp/dumpfile/heap", "-XX:MaxRAMPercentage=50.0", "-XX:+UseContainerSupport", "-XX:+PrintExtendedThreadInfo"]
+  jvmOptions: ["-Xms1536m", "-Xmx3g", "-XX:MaxDirectMemorySize=4g", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/tmp/dumpfile/heap", "-XX:MaxRAMPercentage=50.0", "-XX:+UseContainerSupport", "-XX:+PrintExtendedThreadInfo"]
 
 options:
   bookkeeper.ensemble.size: "3"
@@ -40,7 +40,7 @@ options:
   bookkeeper.ack.quorum.size: "3"
   bookkeeper.write.timeout.milliseconds: "60000"
   bookkeeper.write.outstanding.bytes.max: "33554432"
-  pravegaservice.cache.size.max: "3221225472"
+  pravegaservice.cache.size.max: "2147483648"
   pravegaservice.cache.time.seconds.max: "600"
   hdfs.block.size: "67108864"
   writer.flush.threshold.bytes: "67108864"

--- a/charts/pravega/values/medium.yaml
+++ b/charts/pravega/values/medium.yaml
@@ -32,7 +32,7 @@ segmentStore:
     ## used to override the service type for segmentStore
     type:
     annotations: {}
-  jvmOptions: ["-Xms1536m", "-Xmx3g", "-XX:MaxDirectMemorySize=4g", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/tmp/dumpfile/heap", "-XX:MaxRAMPercentage=50.0", "-XX:+UseContainerSupport", "-XX:+PrintExtendedThreadInfo"]
+  jvmOptions: ["-Xms3g", "-Xmx3g", "-XX:MaxDirectMemorySize=4g", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/tmp/dumpfile/heap", "-XX:MaxRAMPercentage=50.0", "-XX:+UseContainerSupport", "-XX:+PrintExtendedThreadInfo"]
 
 options:
   bookkeeper.ensemble.size: "3"

--- a/charts/pravega/values/small.yaml
+++ b/charts/pravega/values/small.yaml
@@ -32,7 +32,7 @@ segmentStore:
     ## used to override the service type for segmentStore
     type:
     annotations: {}
-  jvmOptions: ["-Xmx2g", "-XX:MaxDirectMemorySize=2g", "-XX:MaxDirectMemorySize=2g", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/tmp/dumpfile/heap", "-XX:MaxRAMPercentage=50.0", "-XX:+UseContainerSupport", "-XX:+PrintExtendedThreadInfo"]
+  jvmOptions: ["-Xms512m", "-Xmx1g", "-XX:MaxDirectMemorySize=2560m", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/tmp/dumpfile/heap", "-XX:MaxRAMPercentage=50.0", "-XX:+UseContainerSupport", "-XX:+PrintExtendedThreadInfo"]
 
 options:
   bookkeeper.ensemble.size: "3"
@@ -40,7 +40,7 @@ options:
   bookkeeper.ack.quorum.size: "3"
   bookkeeper.write.timeout.milliseconds: "60000"
   bookkeeper.write.outstanding.bytes.max: "33554432"
-  pravegaservice.cache.size.max: "1073741824"
+  pravegaservice.cache.size.max: "1610612736"
   pravegaservice.cache.time.seconds.max: "600"
   hdfs.block.size: "67108864"
   writer.flush.threshold.bytes: "67108864"

--- a/charts/pravega/values/small.yaml
+++ b/charts/pravega/values/small.yaml
@@ -32,7 +32,7 @@ segmentStore:
     ## used to override the service type for segmentStore
     type:
     annotations: {}
-  jvmOptions: ["-Xms512m", "-Xmx1g", "-XX:MaxDirectMemorySize=2560m", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/tmp/dumpfile/heap", "-XX:MaxRAMPercentage=50.0", "-XX:+UseContainerSupport", "-XX:+PrintExtendedThreadInfo"]
+  jvmOptions: ["-Xms1g", "-Xmx1g", "-XX:MaxDirectMemorySize=2560m", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/tmp/dumpfile/heap", "-XX:MaxRAMPercentage=50.0", "-XX:+UseContainerSupport", "-XX:+PrintExtendedThreadInfo"]
 
 options:
   bookkeeper.ensemble.size: "3"


### PR DESCRIPTION
Signed-off-by: Nishant Gupta <Nishant_Gupta3@dell.com>

### Change log description

Modifying the default values for JVM options **-Xmx** (maximum heap size of JVM) and **-XX:MaxDirectMemorySize** (segement store direct memory) and also the value of standard option, **pravegaservice.cache.size.max** (Segment Store read cache size)

### Purpose of the change

Fixes #48 

### What the code does

While configuring the memory settings for segment store certain guidelines need to be followed as show below and the code fixes the same in all the sizing manifests

- Host Memory (Pod, VM) = JVM Heap (-Xmx) + JVM Direct Memory (-XX:MaxDirectMemorySize) + unallocated Memory 
   where unallocated memory should be in range of (0.5 -1 GB) to avoid host machine crash due to lack of memory.

-  JVM Direct Memory > JVM Heap
   This is because the Segment Store read cache, Netty and the Bookkeeper client thereby making a significant use of direct 
    memory as a result of an IO workload.

-   Reserve at least 1GB or 2GB for Netty and Bookkeeper client in the Segment Store, and assign the rest of direct memory to 
     the read cache (pravegaservice.cache.size.max).

### How to verify it

After installing the pravega using helm charts, run the command `kubectl describe pk pravega` and verify whether all the values are set as defined in the manifests file.

### Checklist

- [x] PR title starts with the name of the chart followed by the issue number (e.g. `[bookkeeper-operator] Issue XX: "Description"`)
- [x] Verified output of helm lint
- [x] Changes have been tested manually
