### PR TITLE
[pravega] Issue 50: Allow deployment of multiple pravega clusters with external access

### DIFF
--- a/charts/pravega/README.md
+++ b/charts/pravega/README.md
@@ -32,6 +32,8 @@ where:
 
 >Note: If we provide [RELEASE_NAME] same as chart name, cluster name will be same as release-name. But if we are providing a different name for release(other than pravega in this case), cluster name will be [RELEASE_NAME]-[chart-name]. However, cluster name can be overridden by providing `--set  fullnameOverride=[CLUSTER_NAME]` along with helm install command.
 
+>Note: If we are using fullnameOverride, make sure that resource names are not clashing with another deployment.
+
 This command deploys pravega on the Kubernetes cluster in its default configuration. The [configuration](#pravega-configuration) section lists the parameters that can be configured during installation.
 
 >Note: If the underlying pravega operator version is 0.4.5, bookkeeperUri should not be set, and the pravega-bk chart should be used instead of the pravega chart

--- a/charts/pravega/templates/clusterrole.yaml
+++ b/charts/pravega/templates/clusterrole.yaml
@@ -1,9 +1,8 @@
 {{- if .Values.externalAccess.enabled }}
-{{- if not (lookup "rbac.authorization.k8s.io/v1" "ClusterRole" "" .Values.serviceAccount.name) }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Values.serviceAccount.name }}
+  name: {{ template "pravega.fullname" . }}-{{ .Release.Namespace }}-service-account
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "pravega.commonLabels" . | indent 4 }}
@@ -14,5 +13,4 @@ rules:
   - nodes
   verbs:
   - get
-{{- end }}
 {{- end }}

--- a/charts/pravega/templates/clusterrole.yaml
+++ b/charts/pravega/templates/clusterrole.yaml
@@ -3,7 +3,6 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "pravega.fullname" . }}-{{ .Release.Namespace }}
-  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "pravega.commonLabels" . | indent 4 }}
 rules:

--- a/charts/pravega/templates/clusterrole.yaml
+++ b/charts/pravega/templates/clusterrole.yaml
@@ -2,7 +2,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ template "pravega.fullname" . }}-{{ .Release.Namespace }}-service-account
+  name: {{ template "pravega.fullname" . }}-{{ .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "pravega.commonLabels" . | indent 4 }}

--- a/charts/pravega/templates/clusterrole.yaml
+++ b/charts/pravega/templates/clusterrole.yaml
@@ -2,7 +2,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ template "pravega.fullname" . }}-{{ .Release.Namespace }}
+  name: {{ template "pravega.fullname" . }}-pravega-{{ .Release.Namespace }}
   labels:
 {{ include "pravega.commonLabels" . | indent 4 }}
 rules:

--- a/charts/pravega/templates/clusterrole.yaml
+++ b/charts/pravega/templates/clusterrole.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.externalAccess.enabled }}
+{{- if not (lookup "rbac.authorization.k8s.io/v1" "ClusterRole" "" .Values.serviceAccount.name) }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -13,4 +14,5 @@ rules:
   - nodes
   verbs:
   - get
+{{- end }}
 {{- end }}

--- a/charts/pravega/templates/clusterrole.yaml
+++ b/charts/pravega/templates/clusterrole.yaml
@@ -2,7 +2,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ template "pravega.fullname" . }}-pravega-{{ .Release.Namespace }}
+  name: {{ template "pravega.fullname" . }}-{{ .Release.Namespace }}
   labels:
 {{ include "pravega.commonLabels" . | indent 4 }}
 rules:

--- a/charts/pravega/templates/clusterrolebinding.yaml
+++ b/charts/pravega/templates/clusterrolebinding.yaml
@@ -2,7 +2,7 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: {{ template "pravega.fullname" . }}-{{ .Release.Namespace }}
+  name: {{ template "pravega.fullname" . }}-pravega-{{ .Release.Namespace }}
   labels:
 {{ include "pravega.commonLabels" . | indent 4 }}
 subjects:
@@ -11,6 +11,6 @@ subjects:
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: {{ template "pravega.fullname" . }}-{{ .Release.Namespace }}
+  name: {{ template "pravega.fullname" . }}-pravega-{{ .Release.Namespace }}
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/charts/pravega/templates/clusterrolebinding.yaml
+++ b/charts/pravega/templates/clusterrolebinding.yaml
@@ -3,7 +3,6 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: {{ template "pravega.fullname" . }}-{{ .Release.Namespace }}
-  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "pravega.commonLabels" . | indent 4 }}
 subjects:

--- a/charts/pravega/templates/clusterrolebinding.yaml
+++ b/charts/pravega/templates/clusterrolebinding.yaml
@@ -2,16 +2,16 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: {{ template "pravega.fullname" . }}-{{ .Release.Namespace }}-service-account
+  name: {{ template "pravega.fullname" . }}-{{ .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "pravega.commonLabels" . | indent 4 }}
 subjects:
 - kind: ServiceAccount
-  name: {{ template "pravega.fullname" . }}-service-account
+  name: {{ template "pravega.fullname" . }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: {{ template "pravega.fullname" . }}-{{ .Release.Namespace }}-service-account
+  name: {{ template "pravega.fullname" . }}-{{ .Release.Namespace }}
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/charts/pravega/templates/clusterrolebinding.yaml
+++ b/charts/pravega/templates/clusterrolebinding.yaml
@@ -1,19 +1,17 @@
 {{- if .Values.externalAccess.enabled }}
-{{- if not (lookup "rbac.authorization.k8s.io/v1beta1" "ClusterRoleBinding" "" .Values.serviceAccount.name) }}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: {{ .Values.serviceAccount.name }}
+  name: {{ template "pravega.fullname" . }}-{{ .Release.Namespace }}-service-account
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "pravega.commonLabels" . | indent 4 }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.serviceAccount.name }}
+  name: {{ template "pravega.fullname" . }}-service-account
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: {{ .Values.serviceAccount.name }}
+  name: {{ template "pravega.fullname" . }}-{{ .Release.Namespace }}-service-account
   apiGroup: rbac.authorization.k8s.io
-{{- end }}
 {{- end }}

--- a/charts/pravega/templates/clusterrolebinding.yaml
+++ b/charts/pravega/templates/clusterrolebinding.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.externalAccess.enabled }}
+{{- if not (lookup "rbac.authorization.k8s.io/v1beta1" "ClusterRoleBinding" "" .Values.serviceAccount.name) }}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
@@ -14,4 +15,5 @@ roleRef:
   kind: ClusterRole
   name: {{ .Values.serviceAccount.name }}
   apiGroup: rbac.authorization.k8s.io
+{{- end }}
 {{- end }}

--- a/charts/pravega/templates/clusterrolebinding.yaml
+++ b/charts/pravega/templates/clusterrolebinding.yaml
@@ -2,7 +2,7 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: {{ template "pravega.fullname" . }}-pravega-{{ .Release.Namespace }}
+  name: {{ template "pravega.fullname" . }}-{{ .Release.Namespace }}
   labels:
 {{ include "pravega.commonLabels" . | indent 4 }}
 subjects:
@@ -11,6 +11,6 @@ subjects:
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: {{ template "pravega.fullname" . }}-pravega-{{ .Release.Namespace }}
+  name: {{ template "pravega.fullname" . }}-{{ .Release.Namespace }}
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/charts/pravega/templates/pravega.yaml
+++ b/charts/pravega/templates/pravega.yaml
@@ -60,8 +60,8 @@ spec:
 {{ toYaml .Values.segmentStore.affinity | indent 6 }}
     {{- end }}
     {{- if .Values.externalAccess.enabled }}
-    controllerServiceAccountName: {{ .Values.serviceAccount.name }}
-    segmentStoreServiceAccountName: {{ .Values.serviceAccount.name }}
+    controllerServiceAccountName: {{ template "pravega.fullname" . }}-service-account
+    segmentStoreServiceAccountName: {{ template "pravega.fullname" . }}-service-account
     {{- if .Values.segmentStore.service.loadBalancerIP }}
     segmentStoreLoadBalancerIP: {{ .Values.segmentStore.service.loadBalancerIP  }}
     {{- end }}

--- a/charts/pravega/templates/pravega.yaml
+++ b/charts/pravega/templates/pravega.yaml
@@ -60,8 +60,8 @@ spec:
 {{ toYaml .Values.segmentStore.affinity | indent 6 }}
     {{- end }}
     {{- if .Values.externalAccess.enabled }}
-    controllerServiceAccountName: {{ template "pravega.fullname" . }}-service-account
-    segmentStoreServiceAccountName: {{ template "pravega.fullname" . }}-service-account
+    controllerServiceAccountName: {{ template "pravega.fullname" . }}
+    segmentStoreServiceAccountName: {{ template "pravega.fullname" . }}
     {{- if .Values.segmentStore.service.loadBalancerIP }}
     segmentStoreLoadBalancerIP: {{ .Values.segmentStore.service.loadBalancerIP  }}
     {{- end }}

--- a/charts/pravega/templates/role.yaml
+++ b/charts/pravega/templates/role.yaml
@@ -2,7 +2,7 @@
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ template "pravega.fullname" . }}-service-account
+  name: {{ template "pravega.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "pravega.commonLabels" . | indent 4 }}

--- a/charts/pravega/templates/role.yaml
+++ b/charts/pravega/templates/role.yaml
@@ -1,9 +1,8 @@
 {{- if .Values.externalAccess.enabled }}
-{{- if not (lookup "rbac.authorization.k8s.io/v1" "Role" .Release.Namespace .Values.serviceAccount.name) }}
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Values.serviceAccount.name }}
+  name: {{ template "pravega.fullname" . }}-service-account
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "pravega.commonLabels" . | indent 4 }}
@@ -21,5 +20,4 @@ rules:
   - services
   verbs:
   - get
-{{- end }}
 {{- end }}

--- a/charts/pravega/templates/role.yaml
+++ b/charts/pravega/templates/role.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.externalAccess.enabled }}
+{{- if not (lookup "rbac.authorization.k8s.io/v1" "Role" .Release.Namespace .Values.serviceAccount.name) }}
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -20,4 +21,5 @@ rules:
   - services
   verbs:
   - get
+{{- end }}
 {{- end }}

--- a/charts/pravega/templates/rolebinding.yaml
+++ b/charts/pravega/templates/rolebinding.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.externalAccess.enabled }}
+{{- if not (lookup "rbac.authorization.k8s.io/v1" "RoleBinding" .Release.Namespace .Values.serviceAccount.name) }}
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -14,4 +15,5 @@ roleRef:
   kind: Role
   name: {{ .Values.serviceAccount.name }}
   apiGroup: rbac.authorization.k8s.io
+{{- end }}
 {{- end }}

--- a/charts/pravega/templates/rolebinding.yaml
+++ b/charts/pravega/templates/rolebinding.yaml
@@ -2,16 +2,16 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ template "pravega.fullname" . }}-service-account 
+  name: {{ template "pravega.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "pravega.commonLabels" . | indent 4 }}
 subjects:
 - kind: ServiceAccount
-  name: {{ template "pravega.fullname" . }}-service-account 
+  name: {{ template "pravega.fullname" . }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
-  name: {{ template "pravega.fullname" . }}-service-account 
+  name: {{ template "pravega.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/charts/pravega/templates/rolebinding.yaml
+++ b/charts/pravega/templates/rolebinding.yaml
@@ -1,19 +1,17 @@
 {{- if .Values.externalAccess.enabled }}
-{{- if not (lookup "rbac.authorization.k8s.io/v1" "RoleBinding" .Release.Namespace .Values.serviceAccount.name) }}
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Values.serviceAccount.name }}
+  name: {{ template "pravega.fullname" . }}-service-account 
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "pravega.commonLabels" . | indent 4 }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.serviceAccount.name }}
+  name: {{ template "pravega.fullname" . }}-service-account 
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
-  name: {{ .Values.serviceAccount.name }}
+  name: {{ template "pravega.fullname" . }}-service-account 
   apiGroup: rbac.authorization.k8s.io
-{{- end }}
 {{- end }}

--- a/charts/pravega/templates/service_account.yaml
+++ b/charts/pravega/templates/service_account.yaml
@@ -1,11 +1,9 @@
 {{- if .Values.externalAccess.enabled }}
-{{- if not (lookup "v1" "ServiceAccount" .Release.Namespace .Values.serviceAccount.name) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.serviceAccount.name }}
+  name: {{ template "pravega.fullname" . }}-service-account 
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "pravega.commonLabels" . | indent 4 }}
-{{- end }}
 {{- end }}

--- a/charts/pravega/templates/service_account.yaml
+++ b/charts/pravega/templates/service_account.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "pravega.fullname" . }}-service-account 
+  name: {{ template "pravega.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "pravega.commonLabels" . | indent 4 }}

--- a/charts/pravega/templates/service_account.yaml
+++ b/charts/pravega/templates/service_account.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.externalAccess.enabled }}
+{{- if not (lookup "v1" "ServiceAccount" .Release.Namespace .Values.serviceAccount.name) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -6,4 +7,5 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "pravega.commonLabels" . | indent 4 }}
+{{- end }}
 {{- end }}

--- a/charts/pravega/values.yaml
+++ b/charts/pravega/values.yaml
@@ -42,9 +42,6 @@ hooks:
 
 debugLogging: false
 
-serviceAccount:
-  name: pravega-components
-
 controller:
   replicas: 1
   maxUnavailableReplicas:


### PR DESCRIPTION
Signed-off-by: anishakj <anisha.kj@dell.com>

### Change log description

Currently, in the charts we are creating service account roles and role bindings if external access is enabled. But there is no check to enforce they are already present. Due to that after one cluster deployed, second cluster deployment failing with error resource already exists

### Purpose of the change

 Fixes #50

### What the code does

In charts, added a check to verify the existence of resources before  creating it

### How to verify it

Verified that able to deploy more than one cluster with external access

### Checklist

_(Place an '[x]' (no spaces) in all applicable fields)_

- [x] PR title starts with the name of the chart followed by the issue number (e.g. `[bookkeeper-operator] Issue XX: "Description"`)
- [x] Verified output of helm lint
- [x] Changes have been tested manually
