### PR TITLE
[bookkeeper-operator] Issue 55: Bumping chart version to 0.2.2

### DIFF
--- a/charts/bookkeeper-operator/Chart.yaml
+++ b/charts/bookkeeper-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: bookkeeper-operator
 description: Bookkeeper Operator Helm chart for Kubernetes
-version: 0.2.1
+version: 0.2.2
 appVersion: 0.1.6
 keywords:
   - log storage


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@emc.com>

### Change log description
Bumps up the bookkeeper operator chart version to 0.2.2

### Purpose of the change
Fixes #55 

### What the code does
Bumps up the bookkeeper operator chart version to 0.2.1

### How to verify it
N.A.

### Checklist
- [x] PR title starts with the name of the chart followed by the issue number
- [x] Verified output of helm lint
- [x] Changes have been tested manually
