### PR TITLE
[bookkeeper] Issue 57: Bumping chart version to 0.10.2

### DIFF
--- a/charts/bookkeeper/Chart.yaml
+++ b/charts/bookkeeper/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: bookkeeper
 description: Bookkeeper Helm chart for Kubernetes
-version: 0.10.1
+version: 0.10.2
 appVersion: 0.9.1
 keywords:
   - log storage


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@emc.comT>

### Change log description
Bumps up the bookkeeper chart version to 0.10.2

### Purpose of the change
Fixes #57 

### What the code does
Bumps up the bookkeeper chart version to 0.10.2

### How to verify it
N.A.

### Checklist
- [x] PR title starts with the name of the chart followed by the issue number
- [x] Verified output of helm lint
- [x] Changes have been tested manually
