### PR TITLE
[bookkeeper] Issue 59: Adding rollback hooks for Bookkeeper

### DIFF
--- a/charts/bookkeeper/templates/post-install-upgrade-rollback-hooks.yaml
+++ b/charts/bookkeeper/templates/post-install-upgrade-rollback-hooks.yaml
@@ -1,10 +1,10 @@
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ template "bookkeeper.fullname" . }}-post-install-upgrade
+  name: {{ template "bookkeeper.fullname" . }}-post-install-upgrade-rollback
   namespace: {{ .Release.Namespace }}
   annotations:
-    "helm.sh/hook": post-install, post-upgrade
+    "helm.sh/hook": post-install, post-upgrade, post-rollback
     "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation, hook-failed
 rules:
@@ -20,19 +20,19 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ template "bookkeeper.fullname" . }}-post-install-upgrade
+  name: {{ template "bookkeeper.fullname" . }}-post-install-upgrade-rollback
   namespace: {{ .Release.Namespace }}
   annotations:
-    "helm.sh/hook": post-install, post-upgrade
+    "helm.sh/hook": post-install, post-upgrade, post-rollback
     "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation, hook-failed
 subjects:
 - kind: ServiceAccount
-  name: {{ template "bookkeeper.fullname" . }}-post-install-upgrade
+  name: {{ template "bookkeeper.fullname" . }}-post-install-upgrade-rollback
   namespace: {{.Release.Namespace}}
 roleRef:
   kind: Role
-  name: {{ template "bookkeeper.fullname" . }}-post-install-upgrade
+  name: {{ template "bookkeeper.fullname" . }}-post-install-upgrade-rollback
   apiGroup: rbac.authorization.k8s.io
 
 ---
@@ -40,10 +40,10 @@ roleRef:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "bookkeeper.fullname" . }}-post-install-upgrade
+  name: {{ template "bookkeeper.fullname" . }}-post-install-upgrade-rollback
   namespace: {{ .Release.Namespace }}
   annotations:
-    "helm.sh/hook": post-install, post-upgrade
+    "helm.sh/hook": post-install, post-upgrade, post-rollback
     "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation, hook-failed
 
@@ -52,10 +52,10 @@ metadata:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "bookkeeper.fullname" . }}-post-install-upgrade
+  name: {{ template "bookkeeper.fullname" . }}-post-install-upgrade-rollback
   namespace: {{ .Release.Namespace }}
   annotations:
-    "helm.sh/hook": post-install, post-upgrade
+    "helm.sh/hook": post-install, post-upgrade, post-rollback
     "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation, hook-failed
 data:
@@ -86,22 +86,22 @@ data:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ template "bookkeeper.fullname" . }}-post-install-upgrade
+  name: {{ template "bookkeeper.fullname" . }}-post-install-upgrade-rollback
   namespace: {{ .Release.Namespace }}
   annotations:
-    "helm.sh/hook": post-install, post-upgrade
+    "helm.sh/hook": post-install, post-upgrade, post-rollback
     "helm.sh/hook-weight": "2"
     "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation, hook-failed
 spec:
   backoffLimit: {{ .Values.hooks.backoffLimit }}
   template:
     metadata:
-      name: {{ template "bookkeeper.fullname" . }}-post-install-upgrade
+      name: {{ template "bookkeeper.fullname" . }}-post-install-upgrade-rollback
     spec:
-      serviceAccountName: {{ template "bookkeeper.fullname" . }}-post-install-upgrade
+      serviceAccountName: {{ template "bookkeeper.fullname" . }}-post-install-upgrade-rollback
       restartPolicy: Never
       containers:
-      - name: post-install-upgrade-job
+      - name: post-install-upgrade-rollback-job
         image: "{{ .Values.hooks.image.repository }}:{{ .Values.hooks.image.tag }}"
         command:
           - /scripts/validations.sh
@@ -112,5 +112,5 @@ spec:
       volumes:
         - name: sh
           configMap:
-            name: {{ template "bookkeeper.fullname" . }}-post-install-upgrade
+            name: {{ template "bookkeeper.fullname" . }}-post-install-upgrade-rollback
             defaultMode: 0555


### PR DESCRIPTION
Signed-off-by: Nishant Gupta <Nishant_Gupta3@dell.com>

### Change log description

Adding helm's `post-rollback` hooks so as to ensure that the rollback success or failure message is returned only when the rollback has completed successfully or failed , not immediately.

### Purpose of the change

Fixes #59 
### What the code does

The code adds helm's post-rollback hooks in order for the the rollback success or failed message to be in sync with rollback failure or success

### How to verify it

- Install a specific chart version of bookkeeper (say 0.9.0)
- Upgrade the bookkeeper to an not existing image (say 0.9.6) to purposefully fail the upgrade
- Now Rollback to the previous version

The rollback success message `Rollback was a success! Happy Helming!` should appear once the rollback has completed successfully.

In case the rollback fails ,the following message should appear `Error: timed out waiting for the condition`

### Checklist

- [x] PR title starts with the name of the chart followed by the issue number (e.g. `[bookkeeper-operator] Issue XX: "Description"`)
- [x] Verified output of helm lint
- [x] Changes have been tested manually
