### PR TITLE
[bookkeeper-operator/bookkeeper] Issue 61: Add support to run containers as non-root

### DIFF
--- a/charts/bookkeeper-operator/templates/bookkeeper.pravega.io_bookkeeperclusters_crd.yaml
+++ b/charts/bookkeeper-operator/templates/bookkeeper.pravega.io_bookkeeperclusters_crd.yaml
@@ -834,6 +834,9 @@ spec:
                     value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                   type: object
               type: object
+            runAsPrivilegedUser:
+              description: This is set to run the container as root user
+              type: boolean
             serviceAccountName:
               description: ServiceAccountName configures the service account used
                 on BookKeeper instances

--- a/charts/bookkeeper/README.md
+++ b/charts/bookkeeper/README.md
@@ -151,6 +151,7 @@ The following table lists the configurable parameters of the Bookkeeper chart an
 | `pravegaClusterName` | Name of the pravega cluster | `pravega` |
 | `autoRecovery`| Enable bookkeeper auto-recovery | `true` |
 | `blockOwnerDeletion`| Enable blockOwnerDeletion | `true` |
+| `runAsPrivilegedUser`| Enable running container as root user | `true` |
 | `affinity` | Specifies scheduling constraints on bookie pods | `{}` |
 | `labels` | Labels to be added to the Bookie Pods | |
 | `annotations` | Annotations to be added to the Bookie Pods | |

--- a/charts/bookkeeper/templates/bookkeeper.yaml
+++ b/charts/bookkeeper/templates/bookkeeper.yaml
@@ -27,6 +27,11 @@ spec:
   {{- else }}
   blockOwnerDeletion: false
   {{- end }}
+  {{- if or (.Values.runAsPrivilegedUser) (eq (.Values.runAsPrivilegedUser | toString) "<nil>") }}
+  runAsPrivilegedUser: true
+  {{- else }}
+  runAsPrivilegedUser: false
+  {{- end }}
   {{- if .Values.labels }}
   labels:
 {{ toYaml .Values.labels | indent 4 }}

--- a/charts/bookkeeper/values.yaml
+++ b/charts/bookkeeper/values.yaml
@@ -19,6 +19,7 @@ zookeeperUri: zookeeper-client:2181
 pravegaClusterName: pravega
 autoRecovery: true
 blockOwnerDeletion: true
+runAsPrivilegedUser: true
 affinity: {}
 labels: {}
 annotations: {}


### PR DESCRIPTION
Signed-off-by: anishakj <anisha.kj@dell.com>

### Change log description

Added new field `runAsPrivilegedUser` in CRD and modified charts to support configuration

### Purpose of the change

, Fixes #61

### What the code does

Added new field `runAsPrivilegedUser` in charts and provide support to configure its value

### How to verify it

Verified installation using the charts

### Checklist

_(Place an '[x]' (no spaces) in all applicable fields)_

- [ x] PR title starts with the name of the chart followed by the issue number (e.g. `[bookkeeper-operator] Issue XX: "Description"`)
- [ x] Verified output of helm lint
- [x ] Changes have been tested manually
