### PR TITLE
[pravega] Issue 67: Modify pravega minikube manifest to include JVM options

### DIFF
--- a/charts/pravega/values/minikube.yaml
+++ b/charts/pravega/values/minikube.yaml
@@ -7,7 +7,7 @@ controller:
     limits:
       cpu: 500m
       memory: 1Gi
-  jvmOptions: ["-Xms256m", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/tmp/dumpfile/heap", "-XX:MaxRAMPercentage=50.0", "-XX:+UseContainerSupport", "-XX:+PrintExtendedThreadInfo"]
+  jvmOptions: ["-Xms256m", "-Xmx256m", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/tmp/dumpfile/heap", "-XX:MaxRAMPercentage=50.0", "-XX:+UseContainerSupport", "-XX:+PrintExtendedThreadInfo"]
 
 segmentStore:
   replicas: 1
@@ -18,7 +18,7 @@ segmentStore:
     limits:
       cpu: 500m
       memory: 2Gi
-  jvmOptions: ["-Xms250m", "-Xmx250m", "-XX:MaxDirectMemorySize=640m", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/tmp/dumpfile/heap", "-XX:MaxRAMPercentage=50.0", "-XX:+UseContainerSupport", "-XX:+PrintExtendedThreadInfo"]
+  jvmOptions: ["-Xms256m", "-Xmx256m", "-XX:MaxDirectMemorySize=640m", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/tmp/dumpfile/heap", "-XX:MaxRAMPercentage=50.0", "-XX:+UseContainerSupport", "-XX:+PrintExtendedThreadInfo"]
 
 options:
   bookkeeper.ack.quorum.size: "1"


### PR DESCRIPTION
Signed-off-by: Nishant Gupta <Nishant_Gupta3@dell.com>

### Change log description

Adding Missing JVM options to both Controller and Segment Store in the Pravega minikube manifest file

### Purpose of the change

Fixes #67

### What the code does

Code add the missing JVM options for both Controller and Segment Store

### How to verify it

Deploy a Pravega cluster using minikube manifest and exec into controller/Segment Store pod. Inside the pod we should be able to list all the added JVM options as an env variable. 

### Checklist



- [x] PR title starts with the name of the chart followed by the issue number (e.g. `[bookkeeper-operator] Issue XX: "Description"`)
- [x] Verified output of helm lint
- [x] Changes have been tested manually
