### PR TITLE
[pravega-operator/pravega] Issue 74: Adding support for configuring probes

### DIFF
--- a/charts/pravega-operator/templates/pravega.pravega.io_pravegaclusters_crd.yaml
+++ b/charts/pravega-operator/templates/pravega.pravega.io_pravegaclusters_crd.yaml
@@ -1993,6 +1993,57 @@ spec:
                             type: array
                         type: object
                     type: object
+                  controllerProbes:
+                    description: ControllerProbes specifies the values for configurable
+                      fields of Readiness and Liveness Probes for the controller pods.
+                    properties:
+                      livenessProbe:
+                        properties:
+                          failureThreshold:
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          initialDelaySeconds:
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          periodSeconds:
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          successThreshold:
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          timeoutSeconds:
+                            format: int32
+                            minimum: 0
+                            type: integer
+                        type: object
+                      readinessProbe:
+                        properties:
+                          failureThreshold:
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          initialDelaySeconds:
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          periodSeconds:
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          successThreshold:
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          timeoutSeconds:
+                            format: int32
+                            minimum: 0
+                            type: integer
+                        type: object
+                    type: object
                   controllerReplicas:
                     description: ControllerReplicas defines the number of Controller
                       replicas. Defaults to 0.
@@ -4038,6 +4089,58 @@ spec:
                               - topologyKey
                               type: object
                             type: array
+                        type: object
+                    type: object
+                  segmentStoreProbes:
+                    description: SegmentStoreProbes specifies the values for configurable
+                      fields of Readiness and Liveness Probes for the segmentstore
+                      pods.
+                    properties:
+                      livenessProbe:
+                        properties:
+                          failureThreshold:
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          initialDelaySeconds:
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          periodSeconds:
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          successThreshold:
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          timeoutSeconds:
+                            format: int32
+                            minimum: 0
+                            type: integer
+                        type: object
+                      readinessProbe:
+                        properties:
+                          failureThreshold:
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          initialDelaySeconds:
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          periodSeconds:
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          successThreshold:
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          timeoutSeconds:
+                            format: int32
+                            minimum: 0
+                            type: integer
                         type: object
                     type: object
                   segmentStoreReplicas:

--- a/charts/pravega/README.md
+++ b/charts/pravega/README.md
@@ -142,6 +142,16 @@ The following table lists the configurable parameters of the pravega chart and t
 | `controller.jvmOptions` | JVM Options for controller | `["-Xms512m", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/tmp/dumpfile/heap", "-XX:MaxRAMPercentage=50.0", "-XX:+UseContainerSupport", "-XX:+PrintExtendedThreadInfo"]` |
 | `controller.svcNameSuffix` | suffix for controller service name | `pravega-controller` |
 | `controller.initContainers` | Init Containers to add to controller pods | `[]` |
+| `controller.probes.readiness.initialDelaySeconds` | Number of seconds after the container has started before readiness probe is initiated | `20` |
+| `controller.probes.readiness.periodSeconds` | Number of seconds after which a container running within a pod will be probed | `10` |
+| `controller.probes.readiness.failureThreshold` | Minimum number of consecutive failures for the readiness probe to be considered failed | `3` |
+| `controller.probes.readiness.successThreshold` | Minimum number of consecutive successes for the readiness probe to be considered successful after having failed | `3` |
+| `controller.probes.readiness.timeoutSeconds` | Number of seconds after which the probe times out | `60` |
+| `controller.probes.liveness.initialDelaySeconds` | Number of seconds after the container has started before liveness probe is initiated | `60` |
+| `controller.probes.liveness.periodSeconds` | Number of seconds after which a container running within a pod will be probed | `15` |
+| `controller.probes.liveness.failureThreshold` | Minimum number of consecutive failures for the liveness probe to be considered failed | `4` |
+| `controller.probes.liveness.successThreshold` | Minimum number of consecutive successes for the liveness probe to be considered successful after having failed | `1` |
+| `controller.probes.liveness.timeoutSeconds` | Number of seconds after which the probe times out | `5` |
 | `segmentStore.replicas` | Number of segmentStore replicas | `1` |
 | `segmentStore.maxUnavailableReplicas` | Maximum number of unavailable replicas possible for segmentStore pdb | |
 | `segmentStore.secret` | Secret configuration for the segmentStore | `{}` |
@@ -162,6 +172,16 @@ The following table lists the configurable parameters of the pravega chart and t
 | `segmentStore.labels` | Labels to add to the segmentStore pods | `{}` |
 | `segmentStore.annotations` | Annotations to add to the segmentStore pods | `{}` |
 | `segmentStore.initContainers` | Init Containers to add to the segmentStore pods | `[]` |
+| `segmentStore.probes.readiness.initialDelaySeconds` | Number of seconds after the container has started before readiness probe is initiated | `10` |
+| `segmentStore.probes.readiness.periodSeconds` | Number of seconds after which a container running within a pod will be probed | `10` |
+| `segmentStore.probes.readiness.failureThreshold` | Minimum number of consecutive failures for the readiness probe to be considered failed | `30` |
+| `segmentStore.probes.readiness.successThreshold` | Minimum number of consecutive successes for the readiness probe to be considered successful after having failed | `1` |
+| `segmentStore.probes.readiness.timeoutSeconds` | Number of times Kubernetes will retry after a readiness probe failure before restarting the container | `5` |
+| `segmentStore.probes.liveness.initialDelaySeconds` | Number of seconds after the container has started before liveness probe is initiated | `300` |
+| `segmentStore.probes.liveness.periodSeconds` | Number of seconds after which a container running within a pod will be probed | `15` |
+| `segmentStore.probes.liveness.failureThreshold` | Minimum number of consecutive failures for the liveness probe to be considered failed | `4` |
+| `segmentStore.probes.liveness.successThreshold` | Minimum number of consecutive successes for the liveness probe to be considered successful after having failed | `1` |
+| `segmentStore.probes.liveness.timeoutSeconds` | Number of seconds after which the probe times out | `5` |
 | `authImplementations` | Plugin configuration to be used | `[]` |
 | `storage.longtermStorage.type` | Type of long term storage backend to be used (filesystem/ecs/hdfs) | `filesystem` |
 | `storage.longtermStorage.filesystem.pvc` | Name of the pre-created PVC, if long term storage type is filesystem | `pravega-tier2` |

--- a/charts/pravega/templates/pravega.yaml
+++ b/charts/pravega/templates/pravega.yaml
@@ -164,6 +164,44 @@ spec:
     segmentStoreJVMOptions:
 {{ toYaml .Values.segmentStore.jvmOptions | indent 6 }}
     {{- end }}
+    {{- if .Values.controller.probes }}
+    controllerProbes:
+      {{- if .Values.controller.probes.readiness }}
+      readinessProbe:
+        initialDelaySeconds: {{ .Values.controller.probes.readiness.initialDelaySeconds | default 20 }}
+        periodSeconds: {{ .Values.controller.probes.readiness.periodSeconds | default 10 }}
+        failureThreshold: {{ .Values.controller.probes.readiness.failureThreshold | default 3 }}
+        successThreshold: {{ .Values.controller.probes.readiness.successThreshold | default 3 }}
+        timeoutSeconds: {{ .Values.controller.probes.readiness.timeoutSeconds | default 60 }}
+      {{- end }}
+      {{- if .Values.controller.probes.liveness }}
+      livenessProbe:
+        initialDelaySeconds: {{ .Values.controller.probes.liveness.initialDelaySeconds | default 60  }}
+        periodSeconds: {{ .Values.controller.probes.liveness.periodSeconds | default 15  }}
+        failureThreshold: {{ .Values.controller.probes.liveness.failureThreshold | default 4 }}
+        successThreshold: {{ .Values.controller.probes.liveness.successThreshold | default 1 }}
+        timeoutSeconds: {{ .Values.controller.probes.liveness.timeoutSeconds | default 5 }}
+      {{- end }}
+    {{- end }}
+    {{- if .Values.segmentStore.probes }}
+    segmentStoreProbes:
+      {{- if .Values.segmentStore.probes.readiness }}
+      readinessProbe:
+        initialDelaySeconds: {{ .Values.segmentStore.probes.readiness.initialDelaySeconds | default 10 }}
+        periodSeconds: {{ .Values.segmentStore.probes.readiness.periodSeconds | default 10 }}
+        failureThreshold: {{ .Values.segmentStore.probes.readiness.failureThreshold | default 30 }}
+        successThreshold: {{ .Values.segmentStore.probes.readiness.successThreshold | default 1 }}
+        timeoutSeconds: {{ .Values.segmentStore.probes.readiness.timeoutSeconds | default 5 }}
+      {{- end }}
+      {{- if .Values.segmentStore.probes.liveness }}
+      livenessProbe:
+        initialDelaySeconds: {{ .Values.segmentStore.probes.liveness.initialDelaySeconds | default 300  }}
+        periodSeconds: {{ .Values.segmentStore.probes.liveness.periodSeconds | default 15  }}
+        failureThreshold: {{ .Values.segmentStore.probes.liveness.failureThreshold | default 4 }}
+        successThreshold: {{ .Values.segmentStore.probes.liveness.successThreshold | default 1 }}
+        timeoutSeconds: {{ .Values.segmentStore.probes.liveness.timeoutSeconds | default 5 }}
+      {{- end }}
+    {{- end }}
     debugLogging: {{ .Values.debugLogging }}
     {{- if .Values.storage.cache }}
     cacheVolumeClaimTemplate:

--- a/charts/pravega/values.yaml
+++ b/charts/pravega/values.yaml
@@ -65,6 +65,19 @@ controller:
   labels: {}
   annotations: {}
   initContainers: []
+  probes: {}
+  # readiness:
+  #   initialDelaySeconds: 20
+  #   periodSeconds: 10
+  #   failureThreshold: 3
+  #   successThreshold: 3
+  #   timeoutSeconds: 60
+  # liveness:
+  #   initialDelaySeconds: 60
+  #   periodSeconds: 15
+  #   failureThreshold: 4
+  #   successThreshold: 1
+  #   timeoutSeconds: 5
 
 segmentStore:
   replicas: 1
@@ -96,6 +109,19 @@ segmentStore:
   stsNameSuffix:
   headlessSvcNameSuffix:
   initContainers: []
+  probes: {}
+  # readiness:
+  #   initialDelaySeconds: 10
+  #   periodSeconds: 10
+  #   failureThreshold: 30
+  #   successThreshold: 1
+  #   timeoutSeconds: 5
+  # liveness:
+  #   initialDelaySeconds: 300
+  #   periodSeconds: 15
+  #   failureThreshold: 4
+  #   successThreshold: 1
+  #   timeoutSeconds: 5
 authImplementations: {}
   # mountPath: "/opt/pravega/pluginlib"
   # authHandlers:


### PR DESCRIPTION
Signed-off-by: anishakj <anisha.kj@dell.com>

### Change log description

Add support for configuring readiness and liveness probes for controller and segmentstore
### Purpose of the change

 Fixes #74

### What the code does

Made changes in CRD to add the new spec field. And made changes in Pravega charts to configure probes.

### How to verify it

Verified that able to configure probes during install

### Checklist

_(Place an '[x]' (no spaces) in all applicable fields)_

- [x] PR title starts with the name of the chart followed by the issue number (e.g. `[bookkeeper-operator] Issue XX: "Description"`)
- [x] Verified output of helm lint
- [x] Changes have been tested manually
