### PR TITLE
[bookkeeper] Issue 79: Updating AppVersion to 0.10.1

### DIFF
--- a/charts/bookkeeper/Chart.yaml
+++ b/charts/bookkeeper/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bookkeeper
 description: Bookkeeper Helm chart for Kubernetes
 version: 0.10.2
-appVersion: 0.9.1
+appVersion: 0.10.1
 keywords:
   - log storage
   - stream storage

--- a/charts/bookkeeper/README.md
+++ b/charts/bookkeeper/README.md
@@ -142,7 +142,7 @@ The following table lists the configurable parameters of the Bookkeeper chart an
 
 | Parameter | Description | Default |
 | ----- | ----------- | ------ |
-| `image.tag` | Image tag | `0.9.1` |
+| `image.tag` | Image tag | `0.10.1` |
 | `image.repository` | Image repository | `pravega/bookkeeper` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `replicas` | Number of bookkeeper replicas | `3` |

--- a/charts/bookkeeper/values.yaml
+++ b/charts/bookkeeper/values.yaml
@@ -5,7 +5,7 @@
 image:
   repository: pravega/bookkeeper
   pullPolicy: IfNotPresent
-  tag: 0.9.1
+  tag: 0.10.1
 
 hooks:
   image:


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@emc.com>

### Change log description
Updating bookkeeper charts to use bookkeeper image 0.10.1

### Purpose of the change
Fixes #79 

### What the code does
Updates the AppVersion and the image version to 0.10.1 inside the bookkeeper charts.

### How to verify it
Running the following commands should install the bookkeeper cluster with image 0.10.1
```
helm install bookkeeper pravega/bookkeeper --version=0.10.2
```

### Checklist
- [x] PR title starts with the name of the chart followed by the issue number (e.g. `[bookkeeper-operator] Issue XX: "Description"`)
- [x] Verified output of helm lint
- [x] Changes have been tested manually
