### PR TITLE
[pravega,bookkeeper] Issue 73,81: Bumping chart version to 0.10.3

### DIFF
--- a/charts/bookkeeper/Chart.yaml
+++ b/charts/bookkeeper/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: bookkeeper
 description: Bookkeeper Helm chart for Kubernetes
-version: 0.10.2
+version: 0.10.3
 appVersion: 0.10.1
 keywords:
   - log storage

--- a/charts/pravega/Chart.yaml
+++ b/charts/pravega/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: pravega
 description: Pravega Helm chart for Kubernetes
-version: 0.10.2
+version: 0.10.3
 appVersion: 0.10.1
 keywords:
 - pravega


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@emc.com>

### Change log description
Bumps up the chart version of pravega and bookkeeper to 0.10.3

### Purpose of the change
Fixes #73 
Fixes #81 

### What the code does
Bumps up the chart version of pravega and bookkeeper to 0.10.3

### How to verify it
N.A.

### Checklist
- [x] PR title starts with the name of the chart followed by the issue number
- [x] Verified output of helm lint
- [x] Changes have been tested manually
