### PR TITLE
[bookkeeper-operator] Issue 83: Fixing bookkeeper-operator pre-delete hook

### DIFF
--- a/charts/bookkeeper-operator/templates/pre-delete-hooks.yaml
+++ b/charts/bookkeeper-operator/templates/pre-delete-hooks.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.hooks.delete }}
+{{- $watchNamespace := .Values.watchNamespace }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
@@ -61,7 +62,13 @@ data:
     exit_code=0
     echo "Checking for BookkeeperCluster Resource"
 
-    ret=$(kubectl get BookkeeperCluster --all-namespaces --no-headers 2>&1)
+    {{- if $watchNamespace }}
+    cmd="kubectl get BookkeeperCluster  -n {{ $watchNamespace }}"
+    {{- else }}
+    cmd="kubectl get BookkeeperCluster --all-namespaces"
+    {{- end }}
+
+    ret=`$cmd --no-headers 2>&1`
     if (echo $ret | grep -e "No resources found" -e "the server doesn't have a resource type \"BookkeeperCluster\"" > /dev/null);
     then
       echo "None"


### PR DESCRIPTION
Signed-off-by: anishakj <anisha.kj@dell.com>

### Change log description

Fixed pre-delete hook of bookkeeper operator

### Purpose of the change

Fixes #83

### What the code does

Made changes to look for bk cluster resources only in the watch namespace of operator, if that is provided
### How to verify it

Verified the below scenarios
 a. Installed a  bkcluster in different namespace operator is not watching
 Able to uninstall operator
b. Installed bk cluster in namespace operator is watching
  Hook is preventing uninstall of operator

### Checklist

_(Place an '[x]' (no spaces) in all applicable fields)_

- [x] PR title starts with the name of the chart followed by the issue number (e.g. `[bookkeeper-operator] Issue XX: "Description"`)
- [x] Verified output of helm lint
- [x] Changes have been tested manually
