### PR TITLE
[pravega-operator] Issue 88: Fixing pravega-operator pre-delete hook

### DIFF
--- a/charts/pravega-operator/templates/pre-delete-hooks.yaml
+++ b/charts/pravega-operator/templates/pre-delete-hooks.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.hooks.delete }}
+{{- $watchNamespace := .Values.watchNamespace }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -61,7 +62,12 @@ data:
     exit_code=0
     echo "Checking for PravegaCluster Resource"
 
-    ret=$(kubectl get PravegaCluster --all-namespaces --no-headers 2>&1)
+    {{- if $watchNamespace }}
+    cmd="kubectl get PravegaCluster -n {{ $watchNamespace }}"
+    {{- else }}
+    cmd="kubectl get PravegaCluster --all-namespaces"
+    {{- end }}
+    ret=`$cmd --no-headers 2>&1`
     if (echo $ret | grep -e "No resources found" -e "the server doesn't have a resource type \"PravegaCluster\"" > /dev/null);
     then
       echo "None"


### PR DESCRIPTION
Signed-off-by: anishakj <anisha.kj@dell.com>

### Change log description

Fixed pre-delete hook of pravega operator

### Purpose of the change

Fixes #88

### What the code does

Made changes to look forpravega cluster resources only in the watch namespace of operator, if that is provided

### How to verify it

Verified the below scenarios
a. Installed a  pravega cluster in different namespace operator is not watching
Able to uninstall operator
b. Installed pravega cluster in namespace operator is watching
Hook is preventing uninstall of operator

### Checklist

_(Place an '[x]' (no spaces) in all applicable fields)_

- [x] PR title starts with the name of the chart followed by the issue number (e.g. `[bookkeeper-operator] Issue XX: "Description"`)
- [x] Verified output of helm lint
- [x] Changes have been tested manually
