### PR TITLE
[pravega-operator] Issue 39: Fixing conversion webhook

### DIFF
--- a/charts/pravega-operator/templates/pravega.pravega.io_pravegaclusters_crd.yaml
+++ b/charts/pravega-operator/templates/pravega.pravega.io_pravegaclusters_crd.yaml
@@ -6,14 +6,15 @@ metadata:
 spec:
   {{- if .Release.IsUpgrade }}
   conversion:
-    conversionReviewVersions: ["v1beta1", "v1alpha1"]
     strategy: Webhook
-    webhookClientConfig:
-      caBundle: {{ .Values.webhookCert.crt }}
-      service:
-        name: pravega-webhook-svc
-        namespace: {{ .Release.Namespace }}
-        path: /convert
+    webhook:
+      conversionReviewVersions: ["v1beta1", "v1alpha1"]
+      clientConfig:
+        caBundle: {{ .Values.webhookCert.crt }}
+        service:
+          name: pravega-webhook-svc
+          namespace: {{ .Release.Namespace }}
+          path: /convert
   {{- end }}
   group: pravega.pravega.io
   names:


### PR DESCRIPTION
Signed-off-by: anishakj <anisha.kj@dell.com>

### Change log description

There was an issue upgrade from v1beta1 to v1 in CRD. It was due to conversion webhook is not in the new format

### Purpose of the change
 Fixes #39

### What the code does

Updated the conversion webhook to `v1` format

### How to verify it

Verified upgrade 
### Checklist

_(Place an '[x]' (no spaces) in all applicable fields)_

- [x] PR title starts with the name of the chart followed by the issue number (e.g. `[bookkeeper-operator] Issue XX: "Description"`)
- [x] Verified output of helm lint
- [x] Changes have been tested manually
