### PR TITLE
[bookkeeper-operator] Issue 93: Update appVersion to 0.1.7 for bookkeeper-operator

### DIFF
--- a/charts/bookkeeper-operator/Chart.yaml
+++ b/charts/bookkeeper-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bookkeeper-operator
 description: Bookkeeper Operator Helm chart for Kubernetes
 version: 0.2.2
-appVersion: 0.1.6
+appVersion: 0.1.7
 keywords:
   - log storage
   - stream storage

--- a/charts/bookkeeper-operator/README.md
+++ b/charts/bookkeeper-operator/README.md
@@ -53,7 +53,7 @@ The following table lists the configurable parameters of the bookkeeper-operator
 | Parameter | Description | Default |
 | ----- | ----------- | ------ |
 | `image.repository` | Image repository | `pravega/bookkeeper-operator` |
-| `image.tag` | Image tag | `0.1.6` |
+| `image.tag` | Image tag | `0.1.7` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `crd.create` | Create bookkeeper CRD | `true` |
 | `rbac.create` | Create RBAC resources | `true` |

--- a/charts/bookkeeper-operator/values.yaml
+++ b/charts/bookkeeper-operator/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: pravega/bookkeeper-operator
-  tag: 0.1.6
+  tag: 0.1.7
   pullPolicy: IfNotPresent
 
 ## Install RBAC roles and bindings.


### PR DESCRIPTION
Signed-off-by: Nishant Gupta <Nishant_Gupta3@dell.com>

### Change log description

Updating appVersion in bookkeeper-operator charts to 0.1.7

### Purpose of the change

Fixes #93

### What the code does
Updates the appVersion from `0.1.6` --> `0.1.7` in bookkeeper-operator charts

### How to verify it
 Try installing the bookkeeper-operator with the command `helm install [RELEASE_NAME] pravega/bookkeeper-operator --version=[VERSION] --set webhookCert.certName=[CERT_NAME] --set webhookCert.secretName=[SECRET_NAME]` and It should install bookkeeper-operator with 0.1.7 image

### Checklist

- [x] PR title starts with the name of the chart followed by the issue number (e.g. `[bookkeeper-operator] Issue XX: "Description"`)
- [x] Verified output of helm lint
- [x] Changes have been tested manually
