### PR TITLE
[pravega-operator] Issue 97: Bumping the chart version to 0.6.3

### DIFF
--- a/charts/pravega-operator/Chart.yaml
+++ b/charts/pravega-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: pravega-operator
 description: Pravega Operator Helm chart for Kubernetes
-version: 0.6.2
+version: 0.6.3
 appVersion: 0.5.6
 keywords:
 - pravega


### PR DESCRIPTION
Signed-off-by: Nishant Gupta <Nishant_Gupta3@dell.com>

### Change log description

Bumps up the pravega operator chart version to 0.6.3
### Purpose of the change

Fixes #97

### What the code does

Bumps up the pravega operator chart version to 0.6.3

### How to verify it

NA

### Checklist

- [x] PR title starts with the name of the chart followed by the issue number (e.g. `[bookkeeper-operator] Issue XX: "Description"`)
- [x] Verified output of helm lint
- [x] Changes have been tested manually
