### PR TITLE
[bookkeeper] Issue 90: Allowing Bookkeeper for upgrade with large replica count

### DIFF
--- a/charts/bookkeeper-operator/README.md
+++ b/charts/bookkeeper-operator/README.md
@@ -5,7 +5,7 @@ Here, we briefly describe how to install [Bookkeeper Operator](https://github.co
 ## Prerequisites
   - Kubernetes 1.16+ with Beta APIs
   - Helm 3.2.1+
-  - Cert-Manager v0.15.0+ or some other certificate management solution in order to manage the webhook service certificates. This can be easily deployed by referring to [this](https://cert-manager.io/docs/installation/kubernetes/)
+  - Cert-Manager v1.0+ or some other certificate management solution in order to manage the webhook service certificates. This can be easily deployed by referring to [this](https://cert-manager.io/docs/installation/kubernetes/)
   - An Issuer and a Certificate (either self-signed or CA signed) in the same namespace that the Bookkeeper Operator will be installed (refer to [this](https://github.com/pravega/bookkeeper-operator/blob/master/deploy/certificate.yaml) manifest to create a self-signed certificate in the default namespace)
 
 ## Installing Bookkeeper-Operator

--- a/charts/bookkeeper/README.md
+++ b/charts/bookkeeper/README.md
@@ -79,6 +79,11 @@ we can also update other configurable parameters at run time. For changing optio
 ```
 helm upgrade bookkeeper charts/bookkeeper --set-string options."minorCompactionInterval=1900"
 ```
+> Note: By default the bookkeeper cluster chart sets post-install-upgrade-rollback hook backoffLimit to 10, which translates into 22 minute timeout before a helm upgrade is marked as failed.
+Taking into account that bookeeper upgrade would require at least two restarts per bookie pod, each of them taking three minutes, the best case for upgrade will take six minutes per bookie, resulting a four-replica BK cluster easily slipping  over the 22 minutes limit.
+Therefore if you are working with large replica, update the post-install-upgrade-rollback hook backoffLimit accordingly.
+For example, for an 84 bookie replicas in large-io-intensive manifest, we might be looking at 8+ hour upgrade with as many as 100 retries.
+
 Please refer [upgrade](https://github.com/pravega/bookkeeper-operator/blob/master/doc/upgrade-cluster.md) for upgrading cluster versions.
 
 ## Uninstalling the Bookkeeper cluster

--- a/charts/pravega-operator/README.md
+++ b/charts/pravega-operator/README.md
@@ -5,7 +5,7 @@ Here, we briefly describe how to install [pravega-operator](https://github.com/p
 ## Prerequisites
   - Kubernetes 1.16+ with Beta APIs
   - Helm 3.2.1+
-  - Cert-Manager v0.15.0+ or some other certificate management solution in order to manage the webhook service certificates. This can be easily deployed by referring to [this](https://cert-manager.io/docs/installation/kubernetes/)
+  - Cert-Manager v1.0+ or some other certificate management solution in order to manage the webhook service certificates. This can be easily deployed by referring to [this](https://cert-manager.io/docs/installation/kubernetes/)
   - An Issuer and a Certificate (either self-signed or CA signed) in the same namespace that the Pravega Operator will be installed (refer to [this certificate.yaml file](https://github.com/pravega/pravega-operator/blob/master/deploy/certificate.yaml) manifest to create a self-signed certificate in the default namespace)
 
 ## Installing Pravega-Operator


### PR DESCRIPTION
Signed-off-by: Nishant Gupta <Nishant_Gupta3@dell.com>

### Change log description

Documenting that the users should deploy the clusters with higher backofflimit if deploying a bookkeeper cluster with a large replica count.

### Purpose of the change

Fixes #90

### What the code does

Updates the documentation to include a note that users should deploy the clusters with higher backofflimit if deploying the bookkeeper cluster with a large replica count

### How to verify it

NA

### Checklist

- [x] PR title starts with the name of the chart followed by the issue number (e.g. `[bookkeeper-operator] Issue XX: "Description"`)
- [x] Verified output of helm lint
- [x] Changes have been tested manually
