### PR TITLE
[pravega] Issue 105: Modifying the default for ledger max size

### DIFF
--- a/charts/pravega/values.yaml
+++ b/charts/pravega/values.yaml
@@ -188,6 +188,7 @@ options:
   bookkeeper.ack.quorum.size: "3"
   bookkeeper.write.timeout.milliseconds: "60000"
   bookkeeper.write.outstanding.bytes.max: "33554432"
+  bookkeeper.ledger.size.max: "268435456"
   pravegaservice.cache.size.max: "1610612736"
   pravegaservice.cache.time.seconds.max: "600"
   pravegaservice.service.listener.port: "12345"

--- a/charts/pravega/values/minikube.yaml
+++ b/charts/pravega/values/minikube.yaml
@@ -24,4 +24,5 @@ options:
   bookkeeper.ack.quorum.size: "1"
   bookkeeper.write.quorum.size: "1"
   bookkeeper.ensemble.size: "1"
+  bookkeeper.ledger.size.max: "268435456"
   pravegaservice.cache.size.max: "402653184"


### PR DESCRIPTION
Signed-off-by: anishakj <anisha.kj@dell.com>

### Change log description

updated `bookkeeper.ledger.size.max` to `256 MB`

### Purpose of the change

 Fixes #105

### What the code does

Updated ledger max size to `256 MB`
### How to verify it

Verified that able to install cluster with this option

### Checklist

_(Place an '[x]' (no spaces) in all applicable fields)_

- [x] PR title starts with the name of the chart followed by the issue number (e.g. `[bookkeeper-operator] Issue XX: "Description"`)
- [x] Verified output of helm lint
- [x] Changes have been tested manually
