### PR TITLE
[pravega] Issue 112: Bumping chart version to 0.10.4

### DIFF
--- a/charts/pravega/Chart.yaml
+++ b/charts/pravega/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: pravega
 description: Pravega Helm chart for Kubernetes
-version: 0.10.3
+version: 0.10.4
 appVersion: 0.10.2
 keywords:
 - pravega


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@emc.com>

### Change log description
Bumps up the chart version of pravega to 0.10.4

### Purpose of the change
Fixes #112 

### What the code does
Bumps up the chart version of pravega to 0.10.4

### How to verify it
N.A.

### Checklist
- [X] PR title starts with the name of the chart followed by the issue number (e.g. `[bookkeeper-operator] Issue XX: "Description"`)
- [X] Verified output of helm lint
- [X] Changes have been tested manually
