### PR TITLE
Issue 116: add support for pravega and bookkeeper pod tolerations

### DIFF
--- a/charts/bookkeeper-operator/templates/bookkeeper.pravega.io_bookkeeperclusters_crd.yaml
+++ b/charts/bookkeeper-operator/templates/bookkeeper.pravega.io_bookkeeperclusters_crd.yaml
@@ -2278,6 +2278,47 @@ spec:
                         type: string
                     type: object
                 type: object
+              tolerations:
+                description: Tolerations for bookie pods
+                items:
+                  description: The pod this Toleration is attached to tolerates
+                    any taint that matches the triple <key,value,effect> using
+                    the matching operator <operator>.
+                  properties:
+                    effect:
+                      description: Effect indicates the taint effect to match.
+                        Empty means match all taint effects. When specified, allowed
+                        values are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys. If the key is empty,
+                        operator must be Exists; this combination means to match
+                        all values and all keys.
+                      type: string
+                    operator:
+                      description: Operator represents a key's relationship to
+                        the value. Valid operators are Exists and Equal. Defaults
+                        to Equal. Exists is equivalent to wildcard for value,
+                        so that a pod can tolerate all taints of a particular
+                        category.
+                      type: string
+                    tolerationSeconds:
+                      description: TolerationSeconds represents the period of
+                        time the toleration (which must be of effect NoExecute,
+                        otherwise this field is ignored) tolerates the taint.
+                        By default, it is not set, which means tolerate the taint
+                        forever (do not evict). Zero and negative values will
+                        be treated as 0 (evict immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: Value is the taint value the toleration matches
+                        to. If the operator is Exists, the value should be empty,
+                        otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
               version:
                 description: "Version is the expected version of the Bookkeeper cluster.
                   The bookkeeper-operator will eventually make the Bookkeeper cluster

--- a/charts/bookkeeper/README.md
+++ b/charts/bookkeeper/README.md
@@ -161,6 +161,7 @@ The following table lists the configurable parameters of the Bookkeeper chart an
 | `labels` | Labels to be added to the Bookie Pods | |
 | `annotations` | Annotations to be added to the Bookie Pods | |
 | `initContainers` | Init Containers to be added to the Bookie Pods | `[]` |
+| `tolerations` | Tolerations to be added to the Bookie Pods | `[]` |
 | `headlessSvcNameSuffix` | suffix for bookkeeper headless service name | `bookie-headless` |
 | `probes.readiness.initialDelaySeconds` | Number of seconds after the container has started before readiness probe is initiated | `20` |
 | `probes.readiness.periodSeconds` | Number of seconds in which readiness probe will be performed | `10` |

--- a/charts/bookkeeper/templates/bookkeeper.yaml
+++ b/charts/bookkeeper/templates/bookkeeper.yaml
@@ -44,6 +44,10 @@ spec:
   initContainers:
 {{ toYaml .Values.initContainers | indent 4 }}
   {{- end }}
+  {{- if .Values.tolerations }}
+  tolerations:
+{{ toYaml .Values.tolerations | indent 4 }}
+  {{- end }}
   {{- if .Values.headlessSvcNameSuffix }}
   headlessSvcNameSuffix: {{ .Values.headlessSvcNameSuffix }}
   {{- end }}

--- a/charts/bookkeeper/values.yaml
+++ b/charts/bookkeeper/values.yaml
@@ -24,6 +24,7 @@ affinity: {}
 labels: {}
 annotations: {}
 initContainers: []
+tolerations: []
 headlessSvcNameSuffix:
 probes:
   readiness:

--- a/charts/pravega-operator/templates/pravega.pravega.io_pravegaclusters_crd.yaml
+++ b/charts/pravega-operator/templates/pravega.pravega.io_pravegaclusters_crd.yaml
@@ -3023,6 +3023,47 @@ spec:
                       type: string
                     description: Labels to be added to the Controller pods
                     type: object
+                  controllerPodTolerations:
+                    description: Tolerations specifies the pod's tolerations.
+                    items:
+                      description: The pod this Toleration is attached to tolerates
+                        any taint that matches the triple <key,value,effect> using
+                        the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match.
+                            Empty means match all taint effects. When specified, allowed
+                            values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty,
+                            operator must be Exists; this combination means to match
+                            all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to
+                            the value. Valid operators are Exists and Equal. Defaults
+                            to Equal. Exists is equivalent to wildcard for value,
+                            so that a pod can tolerate all taints of a particular
+                            category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of
+                            time the toleration (which must be of effect NoExecute,
+                            otherwise this field is ignored) tolerates the taint.
+                            By default, it is not set, which means tolerate the taint
+                            forever (do not evict). Zero and negative values will
+                            be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches
+                            to. If the operator is Exists, the value should be empty,
+                            otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
                   controllerProbes:
                     description: ControllerProbes specifies the values for configurable
                       fields of Readiness and Liveness Probes for the controller pods.
@@ -5170,6 +5211,47 @@ spec:
                       type: string
                     description: Labels to be added to the SegmentStore pods
                     type: object
+                  segmentStorePodTolerations:
+                    description: Tolerations for SegmentStore pods
+                    items:
+                      description: The pod this Toleration is attached to tolerates
+                        any taint that matches the triple <key,value,effect> using
+                        the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match.
+                            Empty means match all taint effects. When specified, allowed
+                            values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty,
+                            operator must be Exists; this combination means to match
+                            all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to
+                            the value. Valid operators are Exists and Equal. Defaults
+                            to Equal. Exists is equivalent to wildcard for value,
+                            so that a pod can tolerate all taints of a particular
+                            category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of
+                            time the toleration (which must be of effect NoExecute,
+                            otherwise this field is ignored) tolerates the taint.
+                            By default, it is not set, which means tolerate the taint
+                            forever (do not evict). Zero and negative values will
+                            be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches
+                            to. If the operator is Exists, the value should be empty,
+                            otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
                   segmentStoreProbes:
                     description: SegmentStoreProbes specifies the values for configurable
                       fields of Readiness and Liveness Probes for the segmentstore

--- a/charts/pravega/README.md
+++ b/charts/pravega/README.md
@@ -150,6 +150,7 @@ The following table lists the configurable parameters of the pravega chart and t
 | `controller.jvmOptions` | JVM Options for controller | `["-Xms512m", "-XX:+ExitOnOutOfMemoryError", "-XX:+CrashOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/tmp/dumpfile/heap", "-XX:MaxRAMPercentage=50.0", "-XX:+UseContainerSupport", "-XX:+PrintExtendedThreadInfo"]` |
 | `controller.svcNameSuffix` | suffix for controller service name | `pravega-controller` |
 | `controller.initContainers` | Init Containers to add to controller pods | `[]` |
+| `controller.tolerations` | Tolerations to add to controller pods | `[]` |
 | `controller.probes.readiness.initialDelaySeconds` | Number of seconds after the container has started before readiness probe is initiated | `20` |
 | `controller.probes.readiness.periodSeconds` | Number of seconds after which a container running within a pod will be probed | `10` |
 | `controller.probes.readiness.failureThreshold` | Minimum number of consecutive failures for the readiness probe to be considered failed | `3` |
@@ -180,6 +181,7 @@ The following table lists the configurable parameters of the pravega chart and t
 | `segmentStore.labels` | Labels to add to the segmentStore pods | `{}` |
 | `segmentStore.annotations` | Annotations to add to the segmentStore pods | `{}` |
 | `segmentStore.initContainers` | Init Containers to add to the segmentStore pods | `[]` |
+| `segmentStore.tolerations` | Tolerations to add to the segmentStore pods | `[]` |
 | `segmentStore.probes.readiness.initialDelaySeconds` | Number of seconds after the container has started before readiness probe is initiated | `10` |
 | `segmentStore.probes.readiness.periodSeconds` | Number of seconds after which a container running within a pod will be probed | `10` |
 | `segmentStore.probes.readiness.failureThreshold` | Minimum number of consecutive failures for the readiness probe to be considered failed | `30` |

--- a/charts/pravega/templates/pravega.yaml
+++ b/charts/pravega/templates/pravega.yaml
@@ -95,6 +95,10 @@ spec:
     controllerInitContainers:
 {{ toYaml .Values.controller.initContainers | indent 6 }}
     {{- end }}
+    {{- if .Values.controller.tolerations }}
+    controllerPodTolerations:
+{{ toYaml .Values.controller.tolerations | indent 6 }}
+    {{- end }}
     {{- if .Values.segmentStore.labels }}
     segmentStorePodLabels:
 {{ toYaml .Values.segmentStore.labels | indent 6 }}
@@ -106,6 +110,10 @@ spec:
     {{- if .Values.segmentStore.initContainers }}
     segmentStoreInitContainers:
 {{ toYaml .Values.segmentStore.initContainers | indent 6 }}
+    {{- end }}
+    {{- if .Values.segmentStore.tolerations }}
+    segmentStorePodTolerations:
+{{ toYaml .Values.segmentStore.tolerations | indent 6 }}
     {{- end }}
     image:
       repository: {{ .Values.image.repository }}

--- a/charts/pravega/values.yaml
+++ b/charts/pravega/values.yaml
@@ -65,6 +65,7 @@ controller:
   labels: {}
   annotations: {}
   initContainers: []
+  tolerations: []
   probes: {}
   # readiness:
   #   initialDelaySeconds: 20
@@ -109,6 +110,7 @@ segmentStore:
   stsNameSuffix:
   headlessSvcNameSuffix:
   initContainers: []
+  tolerations: []
   probes: {}
   # readiness:
   #   initialDelaySeconds: 10


### PR DESCRIPTION
Signed-off-by: Alfred Landrum <alfred@leakybucket.org>

### Change log description

Chart support for bookkeeper and pravega pod tolerations.

### Purpose of the change

Closes https://github.com/pravega/charts/issues/116
