### PR TITLE
[pravega] Issue 109: Updating AppVersion to 0.11.0

### DIFF
--- a/charts/pravega/Chart.yaml
+++ b/charts/pravega/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pravega
 description: Pravega Helm chart for Kubernetes
 version: 0.10.4
-appVersion: 0.10.2
+appVersion: 0.11.0
 keywords:
 - pravega
 - storage

--- a/charts/pravega/README.md
+++ b/charts/pravega/README.md
@@ -119,7 +119,7 @@ The following table lists the configurable parameters of the pravega chart and t
 
 | Parameter | Description | Default |
 | ----- | ----------- | ------ |
-| `image.tag` | `Version of Pravega image` | `0.10.2` |
+| `image.tag` | `Version of Pravega image` | `0.11.0` |
 | `image.repository` | Image repository | `pravega/pravega` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `tls` | Pravega security configuration passed to the Pravega processes | `{}` |

--- a/charts/pravega/values.yaml
+++ b/charts/pravega/values.yaml
@@ -32,7 +32,7 @@ externalAccess:
 image:
   repository: pravega/pravega
   pullPolicy: IfNotPresent
-  tag: 0.10.2
+  tag: 0.11.0
 
 hooks:
   image:


### PR DESCRIPTION
Change log description
Updating pravega charts to use pravega image 0.11.0

Purpose of the change
[Fixes #110](https://github.com/pravega/charts/issues/109)

What the code does
Updates the AppVersion and the image version to 0.11.0 inside the pravega charts.

How to verify it
Running the following commands should install the pravega cluster with image 0.11.0

### Checklist

_(Place an '[x]' (no spaces) in all applicable fields)_

- [x] PR title starts with the name of the chart followed by the issue number (e.g. `[bookkeeper-operator] Issue XX: "Description"`)
- [x] Verified output of helm lint
- [x] Changes have been tested manually
