### PR TITLE
[pravega] Issue 121: Bumping chart version to 0.10.5

### DIFF
--- a/charts/pravega/Chart.yaml
+++ b/charts/pravega/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: pravega
 description: Pravega Helm chart for Kubernetes
-version: 0.10.4
+version: 0.10.5
 appVersion: 0.11.0
 keywords:
 - pravega

--- a/charts/pravega/index.yaml
+++ b/charts/pravega/index.yaml
@@ -1,0 +1,3 @@
+apiVersion: v1
+entries: {}
+generated: "2022-05-16T21:56:12.838905494-07:00"


### PR DESCRIPTION
Change log description
Bumps up the chart version of pravega to 0.10.5

Purpose of the change
[Fixes https://github.com/pravega/charts/issues/112](https://github.com/pravega/charts/issues/121)

What the code does
Bumps up the chart version of pravega to 0.10.5

How to verify it
N.A.

Checklist
(Place an '[x]' (no spaces) in all applicable fields)

 PR title starts with the name of the chart followed by the issue number (e.g. [bookkeeper-operator] Issue XX: "Description")
 Verified output of helm lint
 Changes have been tested manually
### Checklist

_(Place an '[x]' (no spaces) in all applicable fields)_

- [ ] PR title starts with the name of the chart followed by the issue number (e.g. `[bookkeeper-operator] Issue XX: "Description"`)
- [ ] Verified output of helm lint
- [ ] Changes have been tested manually
