### PR TITLE
[bookkeeper] Issue 122: Updating AppVersion to 0.10.2

### DIFF
--- a/charts/bookkeeper/Chart.yaml
+++ b/charts/bookkeeper/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bookkeeper
 description: Bookkeeper Helm chart for Kubernetes
 version: 0.10.3
-appVersion: 0.10.1
+appVersion: 0.10.2
 keywords:
   - log storage
   - stream storage

--- a/charts/bookkeeper/README.md
+++ b/charts/bookkeeper/README.md
@@ -147,7 +147,7 @@ The following table lists the configurable parameters of the Bookkeeper chart an
 
 | Parameter | Description | Default |
 | ----- | ----------- | ------ |
-| `image.tag` | Image tag | `0.10.1` |
+| `image.tag` | Image tag | `0.10.2` |
 | `image.repository` | Image repository | `pravega/bookkeeper` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `replicas` | Number of bookkeeper replicas | `3` |

--- a/charts/bookkeeper/values.yaml
+++ b/charts/bookkeeper/values.yaml
@@ -5,7 +5,7 @@
 image:
   repository: pravega/bookkeeper
   pullPolicy: IfNotPresent
-  tag: 0.10.1
+  tag: 0.10.2
 
 hooks:
   image:


### PR DESCRIPTION
Signed-off-by: anishakj <anisha.kj@dell.com>

### Change log description
Updating bookkeeper charts to use bookkeeper image 0.10.2

### Purpose of the change
Fixes #122 

### What the code does
Updates the AppVersion and the image version to 0.10.2 inside the bookkeeper charts.

### How to verify it
Running the following commands should install the bookkeeper cluster with image 0.10.2
```
helm install bookkeeper pravega/bookkeeper --version=0.10.3
```

### Checklist
- [x] PR title starts with the name of the chart followed by the issue number (e.g. `[bookkeeper-operator] Issue XX: "Description"`)
- [x] Verified output of helm lint
- [x] Changes have been tested manually
