### PR TITLE
[pravega] Issue 139: Fix indentation for segmentStoreSvcAnnotations in pravega template

### DIFF
--- a/charts/pravega/templates/pravega.yaml
+++ b/charts/pravega/templates/pravega.yaml
@@ -80,7 +80,7 @@ spec:
     {{- end }}
     {{- if .Values.segmentStore.service.annotations }}
     segmentStoreSvcAnnotations:
-  {{ toYaml .Values.segmentStore.service.annotations | indent 6 }}
+{{ toYaml .Values.segmentStore.service.annotations | indent 6 }}
     {{- end }}
     {{- end }}
     {{- if .Values.controller.labels }}


### PR DESCRIPTION
Signed-off-by: Ondřej Kobližek <koblizeko@gmail.com>

### Change log description

Fix indentation for segmentStoreSvcAnnotations in pravega template

### Purpose of the change

Fixes #139 

### What the code does

Fix bad indentation

### How to verify it

Generate helm template for pravega with enabled external access and more than one annotations in `segmentStore.service.annotations`

### Checklist

- [x] PR title starts with the name of the chart followed by the issue number (e.g. `[bookkeeper-operator] Issue XX: "Description"`)
- [x] Verified output of helm lint
- [x] Changes have been tested manually
