### PR TITLE
[pravega] Issue 146: Bumping chart version to 0.10.6

### DIFF
--- a/charts/pravega/Chart.yaml
+++ b/charts/pravega/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: pravega
 description: Pravega Helm chart for Kubernetes
-version: 0.10.5
+version: 0.10.6
 appVersion: 0.12.0
 keywords:
 - pravega


### PR DESCRIPTION
Signed-off-by: anisha.kj <anisha.kj@dell.com>

### Change log description

Bumps up the chart version of pravega to 0.10.6
### Purpose of the change

 Fixes #146

### What the code does

Bumps up the chart version of pravega to 0.10.6

### How to verify it
N/A

### Checklist

_(Place an '[x]' (no spaces) in all applicable fields)_

- [x] PR title starts with the name of the chart followed by the issue number (e.g. `[bookkeeper-operator] Issue XX: "Description"`)
- [x] Verified output of helm lint
- [x] Changes have been tested manually
