### PR TITLE
[bookkeeper] Issue 148: Increase the readiness timeout in bookkeeper cluster charts

### DIFF
--- a/charts/bookkeeper/values.yaml
+++ b/charts/bookkeeper/values.yaml
@@ -33,10 +33,10 @@ headlessSvcNameSuffix:
 probes:
   readiness:
     initialDelaySeconds: 20
-    periodSeconds: 10
+    periodSeconds: 20
     failureThreshold: 9
     successThreshold: 1
-    timeoutSeconds: 5
+    timeoutSeconds: 10
   liveness:
     initialDelaySeconds: 60
     periodSeconds: 15


### PR DESCRIPTION
Signed-off-by: anisha.kj <anisha.kj@dell.com>

### Change log description
Increased the readiness timeout in bookkeeper cluster charts

### Purpose of the change

Fixes #148

### What the code does
Increase the readiness probe timeout and period seconds

### How to verify it

Verified that Readiness probe check is passing in slow clusters
### Checklist

_(Place an '[x]' (no spaces) in all applicable fields)_

- [x] PR title starts with the name of the chart followed by the issue number (e.g. `[bookkeeper-operator] Issue XX: "Description"`)
- [x] Verified output of helm lint
- [x] Changes have been tested manually
