### PR TITLE
[pravega-operator] Issue 165: Update appVersion to 0.5.7 for pravega-operator

### DIFF
--- a/charts/pravega-operator/Chart.yaml
+++ b/charts/pravega-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pravega-operator
 description: Pravega Operator Helm chart for Kubernetes
 version: 0.6.3
-appVersion: 0.5.6
+appVersion: 0.5.7
 keywords:
 - pravega
 - storage

--- a/charts/pravega-operator/README.md
+++ b/charts/pravega-operator/README.md
@@ -53,7 +53,7 @@ The following table lists the configurable parameters of the pravega-operator ch
 | Parameter | Description | Default |
 | ----- | ----------- | ------ |
 | `image.repository` | Image repository | `pravega/pravega-operator` |
-| `image.tag` | Image tag | `0.5.6` |
+| `image.tag` | Image tag | `0.5.7` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `crd.create` | Create pravega CRD | `true` |
 | `rbac.create` | Create RBAC resources | `true` |

--- a/charts/pravega-operator/values.yaml
+++ b/charts/pravega-operator/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: pravega/pravega-operator
-  tag: 0.5.6
+  tag: 0.5.7
   pullPolicy: IfNotPresent
 
 securityContext: {}


### PR DESCRIPTION

Signed-off-by: anishakj [anisha.kj@dell.com](mailto:anisha.kj@dell.com)
### Change log description

Updating appVersion in pravega-operator charts to 0.5.7 
### Purpose of the change

Fixes #165

### What the code does

Updates the appVersion from `0.5.6` --> `0.5.7` in pravega-operator charts

### How to verify it

Try installing the pravega-operator with the command `helm install [RELEASE_NAME] pravega/pravega-operator --version=[VERSION] --set webhookCert.certName=[CERT_NAME] --set webhookCert.secretName=[SECRET_NAME]` and It should install pravega-operator with 0.5.7 image

### Checklist

- [x] PR title starts with the name of the chart followed by the issue number (e.g. `[bookkeeper-operator] Issue XX: "Description"`)
- [x] Verified output of helm lint
- [x] Changes have been tested manually
