### PR TITLE
[bookkeeper-operator] Issue 168: Bumping the chart version to 0.2.5

### DIFF
--- a/charts/bookkeeper-operator/Chart.yaml
+++ b/charts/bookkeeper-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: bookkeeper-operator
 description: Bookkeeper Operator Helm chart for Kubernetes
-version: 0.2.4
+version: 0.2.5
 appVersion: 0.1.9
 keywords:
   - log storage


### PR DESCRIPTION
### Change log description
Bumps up the bookkeeper operator chart version to 0.2.5
### Purpose of the change

 Fixes #168

### What the code does

Bumps up the bookkeeper operator chart version to 0.2.5
### How to verify it

NA

### Checklist

- [x] PR title starts with the name of the chart followed by the issue number (e.g. `[bookkeeper-operator] Issue XX: "Description"`)
- [x] Verified output of helm lint
- [x] Changes have been tested manually
